### PR TITLE
Hotfix: proxy URL join dropped Exolix /api/v2 prefix (404 on live)

### DIFF
--- a/__tests__/url.test.ts
+++ b/__tests__/url.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { joinApiUrl } from "@/lib/url";
+
+describe("joinApiUrl", () => {
+  it("preserves the base path prefix when path starts with a slash", () => {
+    // Regression: new URL("/rate", "https://exolix.com/api/v2") drops /api/v2
+    expect(joinApiUrl("https://exolix.com/api/v2", "/rate").href).toBe(
+      "https://exolix.com/api/v2/rate",
+    );
+  });
+
+  it("tolerates a trailing slash on the base", () => {
+    expect(joinApiUrl("https://exolix.com/api/v2/", "/rate").href).toBe(
+      "https://exolix.com/api/v2/rate",
+    );
+  });
+
+  it("works when the base has no path prefix", () => {
+    expect(joinApiUrl("https://chainflip-broker.io", "/quotes").href).toBe(
+      "https://chainflip-broker.io/quotes",
+    );
+  });
+
+  it("accepts paths without a leading slash", () => {
+    expect(joinApiUrl("https://exolix.com/api/v2", "rate").href).toBe(
+      "https://exolix.com/api/v2/rate",
+    );
+  });
+
+  it("appends query params and skips empty values", () => {
+    const url = joinApiUrl("https://chainflip-broker.io", "/quotes", {
+      apiKey: "secret",
+      amount: "100",
+      empty: "",
+    });
+    expect(url.href).toBe(
+      "https://chainflip-broker.io/quotes?apiKey=secret&amount=100",
+    );
+  });
+});

--- a/lib/server/chainflip.ts
+++ b/lib/server/chainflip.ts
@@ -1,4 +1,5 @@
 import "server-only";
+import { joinApiUrl } from "@/lib/url";
 
 // Server-only client for the Dexifier Chainflip broker. The broker API key
 // stays on the server; browsers call the /api/chainflip/* route handlers.
@@ -9,13 +10,7 @@ export async function chainflipGet<T>(path: string, params?: Record<string, stri
   const apiKey = process.env.CHAINFLIP_API_KEY;
   if (!apiKey) throw new Error("CHAINFLIP_API_KEY is not configured");
 
-  const url = new URL(path, BASE_URL);
-  url.searchParams.set("apiKey", apiKey);
-  if (params) {
-    for (const [k, v] of Object.entries(params)) {
-      if (v !== undefined && v !== "") url.searchParams.set(k, v);
-    }
-  }
+  const url = joinApiUrl(BASE_URL, path, { apiKey, ...params });
   const res = await fetch(url, { headers: { Accept: "*/*" }, cache: "no-store" });
   const data = await res.json().catch(() => ({}));
   if (!res.ok) {

--- a/lib/server/exolix.ts
+++ b/lib/server/exolix.ts
@@ -1,4 +1,5 @@
 import "server-only";
+import { joinApiUrl } from "@/lib/url";
 
 // Server-only Exolix client. The API key never reaches the browser bundle —
 // all browser calls go through the /api/exolix/* route handlers.
@@ -16,12 +17,7 @@ function authHeaders(): HeadersInit {
 }
 
 export async function exolixGet<T>(path: string, params?: Record<string, string>): Promise<T> {
-  const url = new URL(path, BASE_URL);
-  if (params) {
-    for (const [k, v] of Object.entries(params)) {
-      if (v !== undefined && v !== "") url.searchParams.set(k, v);
-    }
-  }
+  const url = joinApiUrl(BASE_URL, path, params);
   const res = await fetch(url, { headers: authHeaders(), cache: "no-store" });
   const data = await res.json().catch(() => ({}));
   if (!res.ok) {
@@ -31,7 +27,7 @@ export async function exolixGet<T>(path: string, params?: Record<string, string>
 }
 
 export async function exolixPost<T>(path: string, body: unknown): Promise<T> {
-  const url = new URL(path, BASE_URL);
+  const url = joinApiUrl(BASE_URL, path);
   const res = await fetch(url, {
     method: "POST",
     headers: authHeaders(),

--- a/lib/url.ts
+++ b/lib/url.ts
@@ -1,0 +1,22 @@
+// URL joining for provider API bases.
+//
+// Why not `new URL(path, base)`? Because a leading-slash `path` is treated
+// as absolute and silently drops any path prefix in the base:
+//   new URL("/rate", "https://exolix.com/api/v2").href === "https://exolix.com/rate"
+// This helper concatenates instead, preserving the base's path prefix.
+
+export function joinApiUrl(
+  base: string,
+  path: string,
+  params?: Record<string, string>,
+): URL {
+  const url = new URL(
+    base.replace(/\/+$/, "") + "/" + path.replace(/^\/+/, ""),
+  );
+  if (params) {
+    for (const [k, v] of Object.entries(params)) {
+      if (v !== undefined && v !== "") url.searchParams.set(k, v);
+    }
+  }
+  return url;
+}


### PR DESCRIPTION
## What broke
`new URL("/rate", "https://exolix.com/api/v2")` resolves to `https://exolix.com/rate` — a leading-slash path is treated as absolute, silently dropping the base's `/api/v2` prefix. Every proxied Exolix call (`/api/exolix/*`) therefore 404'd in production after #55. Chainflip was unaffected (its base URL has no path prefix). Verified live: direct Exolix call with the server key returns 200; the proxy returned Exolix's `{}` 404.

## Fix
- New shared `joinApiUrl(base, path, params)` helper that concatenates instead of resolving, preserving the base path prefix and tolerating slash mismatches.
- `lib/server/exolix.ts` and `lib/server/chainflip.ts` both use it.
- 5 regression tests, incl. the exact Exolix case.

## Verification
13/13 unit tests, `tsc --noEmit` clean, eslint clean.