### PR TITLE
Wallet modal: isolate per-namespace connect failures

### DIFF
--- a/app/_components/dexifier/WalletConnectModal.tsx
+++ b/app/_components/dexifier/WalletConnectModal.tsx
@@ -61,8 +61,11 @@ const WalletConnectModal: React.FC<PropsWithChildren<WalletConnectModalProps>> =
     // wallets (MetaMask, Phantom, …) connect directly through handleConnect.
     const result = await handleConnect(walletInfo).catch(console.error);
     if (!result) return;
-    // Multi-namespace wallets need an explicit namespace selection. This is a
-    // multi-chain app, so connect to every namespace the wallet offers.
+    // Multi-namespace wallets (e.g. MetaMask advertising EVM + Solana) need an
+    // explicit namespace selection. This is a multi-chain app, so connect to
+    // every namespace the wallet offers — one at a time, so a namespace that
+    // isn't actually usable (e.g. MetaMask Solana without the Snap) doesn't
+    // abort the others.
     if (result.status === "Detached" || result.status === "namespace") {
       const namespaces =
         (walletInfo as WalletInfoWithExtra & {
@@ -70,8 +73,10 @@ const WalletConnectModal: React.FC<PropsWithChildren<WalletConnectModalProps>> =
         }).properties
           ?.find((p) => p.name === "namespaces")
           ?.value?.data?.map((d) => d.value) ?? [];
-      if (namespaces.length) {
-        await handleConnect(walletInfo, { forceConnectToNamespaces: namespaces }).catch(console.error);
+      for (const namespace of namespaces) {
+        await handleConnect(walletInfo, { forceConnectToNamespaces: [namespace] }).catch((error) =>
+          console.debug(`Namespace ${String(namespace)} not connected:`, error),
+        );
       }
     }
   }


### PR DESCRIPTION
Follow-up to #57 (merged while this was in flight).

Multi-namespace wallets (MetaMask advertises EVM + Solana) now connect namespaces **one at a time** instead of forcing all at once: a namespace that isn't actually usable (e.g. MetaMask Solana without the Snap) is skipped quietly via `console.debug` instead of aborting the batch with an error — while every usable namespace connects.

Verified via scripted-browser probe against production: MetaMask `eth_requestAccounts` fires, EVM connects, modal closes.