### PR TITLE
UI polish: balance formatting, empty-wallet filter, Swap Now reset

### DIFF
--- a/app/_components/dexifier/DexifierCard.tsx
+++ b/app/_components/dexifier/DexifierCard.tsx
@@ -23,6 +23,7 @@ import ConfirmModal from "./ConfirmModal";
 import TooltipTemplate from "../common/tooltip-template";
 import SettingModal from "./SettingModal";
 import { cn } from "@/lib/utils";
+import { formatCryptoAmount } from "@/app/utils";
 
 const DexifierCard: React.FC = () => {
   // Use custom hook to get connected wallet details
@@ -42,7 +43,9 @@ const DexifierCard: React.FC = () => {
     selectedRoute,
     swapData,
     isMobile,
+    state,
     setState,
+    initialize,
   } = useDexifier();
   const [tokenFromBalance, setTokenFromBalance] = useState<number>(0);
 
@@ -119,7 +122,7 @@ const DexifierCard: React.FC = () => {
                 <Label className="text-sm">
                   Balance:{" "}
                   {tokenFromBalance
-                    ? `${tokenFromBalance} ${tokenFrom.symbol}`
+                    ? `${formatCryptoAmount(tokenFromBalance)} ${tokenFrom.symbol}`
                     : "_"}
                 </Label>
                 {tokenFromBalance > 0 && (
@@ -202,12 +205,18 @@ const DexifierCard: React.FC = () => {
           {!selectedRoute?.hasOwnProperty('outputAmount') ? (
             <Button
               className={`bg-primary hover:bg-primary-dark text-black w-full md:max-w-[75%] lg:max-w-[67%] font-semibold h-[3.125rem] mx-auto text-xl disabled:cursor-not-allowed cursor-pointer transition duration-300 ease-out`}
-              disabled={!selectedRoute || !!swapData}
+              disabled={!selectedRoute || state === DEXIFIER_STATE.PENDING || (!!swapData && state < DEXIFIER_STATE.PROCESSING)}
               onClick={() => {
-                setState(DEXIFIER_STATE.WITHDRAWAL_ADDRESS)
+                // After a swap ends (success/failure) offer a reset; during
+                // processing allow cancelling back to a fresh state.
+                if (state >= DEXIFIER_STATE.PROCESSING) {
+                  initialize()
+                } else {
+                  setState(DEXIFIER_STATE.WITHDRAWAL_ADDRESS)
+                }
               }}
             >
-              Swap Now
+              {state === DEXIFIER_STATE.PROCESSING ? "Cancel" : state >= DEXIFIER_STATE.FAILED ? "Swap Again" : "Swap Now"}
             </Button>
           ) : !isWalletConnected ? (
             <WalletConnectModal>

--- a/app/_components/dexifier/RouteCard.tsx
+++ b/app/_components/dexifier/RouteCard.tsx
@@ -24,10 +24,7 @@ import FloatingTooltip from "../common/floating-tooltip";
 import { Blockchain, Token } from "@/app/types/dexifier";
 import { MAP_BLOCKCHAIN_RANGO_2_EXOLIX } from "@/app/utils/exolix";
 import { CHAINFLIP_BLOCKCHAIN_NAME_MAP } from "@/app/utils/chainflip";
-
-// Crypto amounts need real precision: 0.00115 BTC must not render as "0.00".
-const formatCryptoAmount = (n: number): string =>
-  n.toLocaleString("en-US", { maximumSignificantDigits: 8 });
+import { formatCryptoAmount } from "@/app/utils";
 
 const FILTERS = ["Shortest", "Best rate", "Lowest fee", "Fastest"];
 

--- a/app/_components/navbar/MainNavbar.tsx
+++ b/app/_components/navbar/MainNavbar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
+import { formatUsd } from "@/app/utils";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import Image from "next/image";
@@ -37,6 +38,13 @@ const MainNavbar = () => {
 
   const { details: connectedWallets, totalBalance, isLoading } = useWidget().wallets;
   const { list } = useWalletList({})
+
+  // The widget's totalBalance arrives as an unformatted raw-sum string like
+  // "10738.14892158378109848..." — parse and format it before display.
+  const formattedTotalBalance = useMemo(() => {
+    const n = parseFloat(totalBalance ?? "");
+    return Number.isNaN(n) ? "0.00" : formatUsd(n);
+  }, [totalBalance]);
 
   const mappedWallets = connectedWallets.filter((connectedWallets, index, self) =>
     index === self.findIndex((w) => (
@@ -160,7 +168,7 @@ const MainNavbar = () => {
                             />
                           ))}
                         </div>
-                        <span className="flex items-center">{totalBalance} $</span>
+                        <span className="flex items-center">{formattedTotalBalance} $</span>
                       </div>
                     }
                   </button>

--- a/app/_components/navbar/WalletDetails.tsx
+++ b/app/_components/navbar/WalletDetails.tsx
@@ -20,7 +20,7 @@ import { useWalletList, useWidget } from "@rango-dev/widget-embedded";
 import { X } from "lucide-react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { MultiSelect } from "@/components/ui/multi-select";
-import { getAbbrAddress } from "@/app/utils";
+import { formatCryptoAmount, formatUsd, getAbbrAddress } from "@/app/utils";
 import TokenIcon from "../common/token-icon";
 import { TbRefresh } from "react-icons/tb";
 
@@ -103,19 +103,21 @@ const WalletDetails: React.FC<WalletDetailsProps> = ({ children }) => {
 
   useEffect(() => {
     setFilteredWallets(structuredClone(connectedWallets).filter(wallet => {
-      // Exclude wallets with zero balance if 'isHideEmptyWallet' is true
-      if (moreSettingsMemo.includes(MORE_SETTINGS.HIDE_EMPTY_WALLET) && !wallet.balances?.length) return false;
       // Exclude wallets with unselected chains and wallet types
       if (!selectedChainsMemo.includes(wallet.chain) || !selectedWalletTypesMemo.includes(wallet.walletType)) return false;
       // Filter wallets with search term
       if (!wallet.chain.toLowerCase().includes(search.toLowerCase())) return false;
-      // Exclude unsupported tokens in the wallet if 'isHideUnsupportedToken' is true
-      if (moreSettingsMemo.includes(MORE_SETTINGS.HIDE_UNSUPPORTED_TOKEN) && wallet.balances) {
-        // wallet.balances = wallet.balances.filter(balance => getTokenData(balance))
-      }
-      // Exclude tokens with small balance in the wallet if 'isHideSmallBalance' is true
+      // Exclude tokens with small balance in the wallet if 'isHideSmallBalance' is true.
+      // NOTE: this must run BEFORE the empty-wallet check — it can empty a
+      // wallet's token list, and such wallets must then count as empty.
       if (moreSettingsMemo.includes(MORE_SETTINGS.HIDE_SMALL_BALANCE) && wallet.balances) {
         wallet.balances = wallet.balances.filter((balance) => getTokenBalanceInUSD(balance) > 1)
+      }
+      // Exclude wallets with zero balance if 'isHideEmptyWallet' is true:
+      // no tokens left after filtering, or nothing of value.
+      if (moreSettingsMemo.includes(MORE_SETTINGS.HIDE_EMPTY_WALLET)) {
+        if (!wallet.balances?.length) return false;
+        if (getWalletBalanceInUSD([wallet]) === 0) return false;
       }
       return true;
     }).sort((a, b) => getWalletBalanceInUSD([b]) - getWalletBalanceInUSD([a])));
@@ -153,7 +155,7 @@ const WalletDetails: React.FC<WalletDetailsProps> = ({ children }) => {
       <SheetContent className="bg-gradient-to-b to-[#002f19] from-[#01150c] p-4 min-w-[450px] flex flex-col">
         <SheetHeader className="border-b border-separator">
           <SheetTitle className="w-full flex justify-center relative p-2">
-            <span className="text-xl text-primary">{getWalletBalanceInUSD(filteredWallets).toFixed(4)}$</span>
+            <span className="text-xl text-primary">{formatUsd(getWalletBalanceInUSD(filteredWallets))}$</span>
             <SheetClose className="absolute right-2">
               <X className="w-7 h-7 p-1 bg-primary rounded-full font-bold text-black hover:bg-primary-dark transition-colors duration-300" />
             </SheetClose>
@@ -284,7 +286,7 @@ const SubWallet: React.FC<any> = ({
               </Link>
             </TooltipTemplate>
           </div>
-          <span className="text-primary">{balanceInUSD && balanceInUSD.toFixed(3) + "$" || ""}</span>
+          <span className="text-primary">{balanceInUSD ? formatUsd(balanceInUSD) + "$" : ""}</span>
         </div>
       </button>
       <div className="p-2 text-[#e5e7ebc9]">
@@ -305,8 +307,8 @@ const SubWallet: React.FC<any> = ({
                 </div>
               </div>
               <div className="flex flex-col mr-3">
-                <span>{balance.amount}</span>
-                <span className="text-xs">{getTokenBalanceInUSD(balance).toFixed(2)} $</span>
+                <span>{formatCryptoAmount(parseFloat(balance.amount) || 0)}</span>
+                <span className="text-xs">{formatUsd(getTokenBalanceInUSD(balance))} $</span>
               </div>
             </div>
           )

--- a/app/providers/DexifierProvider.tsx
+++ b/app/providers/DexifierProvider.tsx
@@ -304,6 +304,10 @@ const DexifierProvider = ({ children }: { children: ReactNode }) => {
       debounce(async () => {
         if (tokenFrom && tokenTo && amountFrom && parseFloat(amountFrom)) {
           setState(DEXIFIER_STATE.FETCHING_ROUTES)
+          // A new quote session invalidates any previous swap — otherwise a
+          // stale swapData keeps the Swap Now button disabled forever.
+          setSwapData(undefined)
+          setSwapStatus(undefined)
           const allRoutes = await getRoutes(tokenFrom, tokenTo, amountFrom)
           setRoutes(allRoutes)
           if (allRoutes.length) setSelectedRoute(allRoutes[0])

--- a/app/utils/index.ts
+++ b/app/utils/index.ts
@@ -3,6 +3,14 @@ export const getAbbrAddress = (address: string | null) => {
   return address.slice(0, 4) + "..." + address.slice(-4)
 }
 
+// Crypto amounts need real precision: 0.00115 BTC must not render as "0.00".
+export const formatCryptoAmount = (n: number): string =>
+  n.toLocaleString("en-US", { maximumSignificantDigits: 8 });
+
+// USD totals shown to users: always exactly 2 decimals with grouping.
+export const formatUsd = (n: number): string =>
+  n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
 export function formatReadableDate(date: Date) {
   return date.toLocaleString('en-US', {
     year: 'numeric',


### PR DESCRIPTION
Three UI bugs reported after the wallet/routes fix:

1. **Navbar balance with absurd precision** (`10,738.148921583781098482608644578376359735 $`): the widget's `totalBalance` arrives as a raw float-sum string and was rendered verbatim. Now parsed and formatted as grouped 2-decimal USD (shared `formatUsd`/`formatCryptoAmount` helpers in `app/utils`). Also applied to the wallet-sheet header total (was 4dp), per-wallet totals (was 3dp), per-token amounts (was raw), and the From-field balance.

2. **"Hide empty wallets" didn't hide emptied wallets**: the empty check ran *before* the "hide small balances" token filter, so wallets whose tokens were all filtered out (< $1) still appeared with "No tokens found". Reordered — token filters first, then the empty check — and zero-USD wallets now count as empty too.

3. **Swap Now dead after a swap**: `disabled={!selectedRoute || !!swapData}` — `swapData` was never cleared after success/failure, so the button stayed disabled until a page refresh. Two fixes: route refetches (any input change) now clear `swapData`/`swapStatus`, and the desktop button mirrors the mobile behavior — "Swap Again" after success/failure and "Cancel" while processing, both calling `initialize()`.

tsc clean, eslint 0 errors, 13/13 unit tests.