### PR TITLE
Fix navbar total ($10 bug), restore XMR, amount clear-X

### DIFF
--- a/app/_components/dexifier/DexifierCard.tsx
+++ b/app/_components/dexifier/DexifierCard.tsx
@@ -160,12 +160,13 @@ const DexifierCard: React.FC = () => {
             type="number"
             id="tokenFrom"
             placeholder="Please enter 1-42000000"
-            className="flex-1 border-none bg-transparent focus-visible:ring-0 focus-visible:outline-0 focus-visible:ring-offset-0 placeholder:text-white/50"
+            className="flex-1 border-none bg-transparent focus-visible:ring-0 focus-visible:outline-0 focus-visible:ring-offset-0 placeholder:text-white/50 pr-8"
             value={amountFrom}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
               // e.target.value = parseFloat(e.target.value).toString();
               setAmountFrom(e.target.value);
             }}
+            onClear={() => setAmountFrom("")}
             token={tokenFrom}
             setToken={setTokenFrom}
           />
@@ -195,7 +196,7 @@ const DexifierCard: React.FC = () => {
             disabled
             token={tokenTo}
             setToken={setTokenTo}
-            value={Number(amountTo).toFixed(2)}
+            value={Number(amountTo) ? formatCryptoAmount(Number(amountTo)) : "0"}
           />
         </div>
       </CardContent>

--- a/app/_components/dexifier/TokenInput.tsx
+++ b/app/_components/dexifier/TokenInput.tsx
@@ -7,14 +7,16 @@ import TokenIcon from "../common/token-icon";
 import { useDexifier } from "@/app/providers/DexifierProvider";
 import { cn } from "@/lib/utils";
 import { Blockchain, Token } from "@/app/types/dexifier";
+import { X } from "lucide-react";
 
 // Defining the interface for TokenInput props
 interface TokenInputProps extends InputHTMLAttributes<HTMLInputElement> {
   token: Token | undefined; // Token selected by the user
   setToken: Dispatch<SetStateAction<Token | undefined>>; // Setter function for updating the token state
+  onClear?: () => void; // When provided (editable fields), shows an ✕ button to clear the value
 }
 
-const TokenInput: React.FC<TokenInputProps> = ({ token, setToken, ...props }) => {
+const TokenInput: React.FC<TokenInputProps> = ({ token, setToken, onClear, ...props }) => {
   const { isMobile, chains } = useDexifier();
   // Find the selected blockchain's metadata
   const selectedBlochchain = useMemo<Blockchain | undefined>(() => {
@@ -26,7 +28,19 @@ const TokenInput: React.FC<TokenInputProps> = ({ token, setToken, ...props }) =>
     <div className={cn(`flex border-[#695F5F]/40 items-center justify-between backdrop-blur-lg rounded-lg p-2 shadow-md`, isMobile ? "bg-primary/30 h-12" : "border h-[53px] bg-[#000]/30")}>
       {/* Input field for token amount */}
       <div className="flex flex-col flex-1">
-        <Input {...props} /> {/* Custom input for entering token amount */}
+        <div className="relative">
+          <Input {...props} /> {/* Custom input for entering token amount */}
+          {onClear && !!props.value && (
+            <button
+              type="button"
+              aria-label="Clear amount"
+              onClick={onClear}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-white/40 hover:text-white transition-colors cursor-pointer"
+            >
+              <X size={15} />
+            </button>
+          )}
+        </div>
         <span className="text-xs px-3 opacity-50">
           {/* Display estimated USD value of the token */}
           ~

--- a/app/_components/navbar/MainNavbar.tsx
+++ b/app/_components/navbar/MainNavbar.tsx
@@ -39,10 +39,11 @@ const MainNavbar = () => {
   const { details: connectedWallets, totalBalance, isLoading } = useWidget().wallets;
   const { list } = useWalletList({})
 
-  // The widget's totalBalance arrives as an unformatted raw-sum string like
-  // "10738.14892158378109848..." — parse and format it before display.
+  // The widget's totalBalance arrives as a grouped string like
+  // "10,738.148921583781..." — strip the comma separators before parsing
+  // (parseFloat("10,738...") would stop at the comma and read just 10).
   const formattedTotalBalance = useMemo(() => {
-    const n = parseFloat(totalBalance ?? "");
+    const n = parseFloat((totalBalance ?? "").replace(/,/g, ""));
     return Number.isNaN(n) ? "0.00" : formatUsd(n);
   }, [totalBalance]);
 

--- a/app/api/exolix/sync/route.ts
+++ b/app/api/exolix/sync/route.ts
@@ -1,0 +1,135 @@
+import { prisma } from "@/lib/prisma";
+import { exolixGet } from "@/lib/server/exolix";
+import { NextRequest, NextResponse } from "next/server";
+
+// Re-syncs the Exolix networks/currencies cache in Postgres.
+// Runs daily via Vercel Cron and can be triggered manually with:
+//   curl -X POST -H "Authorization: Bearer $CRON_SECRET" /api/exolix/sync
+
+export const maxDuration = 60;
+
+type ExolixNetwork = {
+  coinNetworkId?: string;
+  network: string;
+  name: string;
+  shortName?: string | null;
+  addressRegex?: string | null;
+  notes?: string | null;
+  isDefault?: boolean;
+  decimal?: number | null;
+  icon?: string | null;
+  blockExplorer?: string | null;
+  depositMinAmount?: number | null;
+  memoNeeded?: boolean;
+};
+
+type ExolixCurrency = {
+  code: string;
+  name: string;
+  icon?: string | null;
+  notes?: string | null;
+  networks: ExolixNetwork[];
+};
+
+type CurrenciesPage = { count: number; data: ExolixCurrency[] };
+
+const PAGE_SIZE = 100;
+
+async function getAllCurrencies(): Promise<ExolixCurrency[]> {
+  const first = await exolixGet<CurrenciesPage>("/currencies", {
+    page: "1",
+    size: String(PAGE_SIZE),
+    withNetworks: "true",
+  });
+  const totalPages = Math.ceil(first.count / PAGE_SIZE);
+  const rest = await Promise.all(
+    Array.from({ length: totalPages - 1 }, (_, i) =>
+      exolixGet<CurrenciesPage>("/currencies", {
+        page: String(i + 2),
+        size: String(PAGE_SIZE),
+        withNetworks: "true",
+      }),
+    ),
+  );
+  return [first, ...rest].flatMap((p) => p.data);
+}
+
+async function handler(request: NextRequest) {
+  const secret = process.env.CRON_SECRET;
+  if (secret && request.headers.get("authorization") !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const currencies = await getAllCurrencies();
+
+    // Networks: dedupe by Exolix network code, insert missing ones.
+    // Whitelist only the schema fields — Exolix sends extra keys
+    // (contract, precision, platformTypes, ...) that Prisma would reject.
+    const networkByCode = new Map<string, Record<string, unknown>>();
+    for (const currency of currencies) {
+      for (const n of currency.networks) {
+        if (networkByCode.has(n.network)) continue;
+        networkByCode.set(n.network, {
+          network: n.network,
+          name: n.name,
+          shortName: n.shortName ?? null,
+          addressRegex: n.addressRegex ?? null,
+          notes: n.notes ?? null,
+          isDefault: n.isDefault ?? false,
+          decimal: n.decimal ?? null,
+          icon: n.icon ?? null,
+          blockExplorer: n.blockExplorer ?? null,
+          depositMinAmount: n.depositMinAmount ?? null,
+          memoNeeded: n.memoNeeded ?? false,
+        });
+      }
+    }
+    await prisma.network.createMany({
+      data: [...networkByCode.values()] as never,
+      skipDuplicates: true,
+    });
+
+    const idByNetwork = new Map(
+      (await prisma.network.findMany()).map((n) => [n.network, n.id]),
+    );
+
+    // Currencies: full refresh (one row per currency-network pair).
+    const rows = currencies.flatMap((c) =>
+      c.networks
+        .map((n) => ({
+          code: c.code,
+          name: c.name,
+          icon: c.icon ?? null,
+          notes: c.notes ?? null,
+          networkId: idByNetwork.get(n.network),
+        }))
+        .filter((r): r is typeof r & { networkId: number } => !!r.networkId),
+    );
+    await prisma.$transaction([
+      prisma.currency.deleteMany({}),
+      prisma.currency.createMany({ data: rows }),
+    ]);
+
+    return NextResponse.json({
+      ok: true,
+      networks: networkByCode.size,
+      currencies: rows.length,
+    });
+  } catch (error) {
+    console.error("Exolix sync failed", error);
+    return NextResponse.json(
+      { error: "Sync failed", detail: error instanceof Error ? error.message : String(error) },
+      { status: 500 },
+    );
+  }
+}
+
+// Vercel Cron issues GET; manual triggers may use POST.
+export async function GET(request: NextRequest) {
+  return handler(request);
+}
+
+export async function POST(request: NextRequest) {
+  return handler(request);
+}

--- a/app/providers/DexifierProvider.tsx
+++ b/app/providers/DexifierProvider.tsx
@@ -24,7 +24,7 @@ import {
   getRangoRoutes,
 } from "@/lib/api-client";
 import axios from "axios";
-import { getExolixflipBlockchainName, MAP_BLOCKCHAIN_RANGO_2_EXOLIX } from "../utils/exolix";
+import { MAP_BLOCKCHAIN_RANGO_2_EXOLIX, resolveExolixNetwork } from "../utils/exolix";
 import { Blockchain, Token } from "../types/dexifier";
 
 // Define the type for the context
@@ -213,9 +213,9 @@ const DexifierProvider = ({ children }: { children: ReactNode }) => {
     try {
       const exolixRateRequest: RateRequest = {
         coinFrom: tokenFrom.symbol,
-        networkFrom: getExolixflipBlockchainName(tokenFrom.blockchain),
+        networkFrom: resolveExolixNetwork(tokenFrom.blockchain, networks),
         coinTo: tokenTo.symbol,
-        networkTo: getExolixflipBlockchainName(tokenTo.blockchain),
+        networkTo: resolveExolixNetwork(tokenTo.blockchain, networks),
         amount: amount,
         rateType: 'float',
       }
@@ -280,9 +280,9 @@ const DexifierProvider = ({ children }: { children: ReactNode }) => {
     if ('toAmount' in selectedRoute) {
       const txRequest: TxRequest = {
         coinFrom: tokenFrom.symbol,
-        networkFrom: tokenFrom.blockchain,
+        networkFrom: resolveExolixNetwork(tokenFrom.blockchain, networks) ?? tokenFrom.blockchain,
         coinTo: tokenTo.symbol,
-        networkTo: tokenTo.blockchain,
+        networkTo: resolveExolixNetwork(tokenTo.blockchain, networks) ?? tokenTo.blockchain,
         amount: parseFloat(amountFrom),
         withdrawalAddress: withdrawalAddress,
         rateType: "float",

--- a/app/utils/exolix.ts
+++ b/app/utils/exolix.ts
@@ -48,3 +48,17 @@ export function getExolixflipBlockchainName(key: string): string | undefined {
   );
   return entry?.[1];
 }
+
+// Resolve a coin's `blockchain` value to an Exolix network code.
+// DB-sourced coins already carry the Exolix code ("XMR", "TRX", ...) — pass
+// it through when it matches a known Exolix network. Rango-sourced coins
+// carry Rango chain names ("SOLANA", ...) — translate via the map, falling
+// back to the raw value so callers behave deterministically.
+export function resolveExolixNetwork(
+  blockchain: string | undefined,
+  exolixNetworks: { network: string }[],
+): string | undefined {
+  if (!blockchain) return undefined;
+  if (exolixNetworks.some((n) => n.network === blockchain)) return blockchain;
+  return getExolixflipBlockchainName(blockchain) ?? blockchain;
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/exolix/sync",
+      "schedule": "0 3 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
1. **Navbar always showed $10**: the widget's `totalBalance` is comma-grouped (`10,738.14…`) — `parseFloat` stops at the comma. Now stripped before parsing.

2. **Monero missing from chain/coin lists**: Rango meta genuinely has no Monero — XMR used to come from the Exolix networks/currencies Postgres cache, which is currently **empty**. This adds a protected `GET/POST /api/exolix/sync` route that re-seeds the cache from Exolix (797 currencies, full `createMany` refresh), wired to a **daily Vercel Cron** (`vercel.json`, `CRON_SECRET` already set in Vercel env). After deploy I'll trigger it once manually.
   - New `resolveExolixNetwork` helper: DB coins already carry Exolix network codes (`XMR`, `TRX`…), so rate/swap calls now pass them through instead of failing the Rango-name→Exolix map lookup.

3. **Amount field UX**: editable From field gets an ✕ clear button; also fixed the To field rounding tiny amounts to `0.00`.

tsc clean, eslint 0 errors, 15/15 tests. Exolix API shape verified against production (797 currencies, nested networks match the Prisma schema).