### PR TITLE
Sync: include required Network fields

### DIFF
--- a/app/api/exolix/sync/route.ts
+++ b/app/api/exolix/sync/route.ts
@@ -21,6 +21,10 @@ type ExolixNetwork = {
   blockExplorer?: string | null;
   depositMinAmount?: number | null;
   memoNeeded?: boolean;
+  memoName?: string | null;
+  memoRegex?: string | null;
+  precision?: number;
+  contract?: string | null;
 };
 
 type ExolixCurrency = {
@@ -82,6 +86,10 @@ async function handler(request: NextRequest) {
           blockExplorer: n.blockExplorer ?? null,
           depositMinAmount: n.depositMinAmount ?? null,
           memoNeeded: n.memoNeeded ?? false,
+          memoName: n.memoName ?? null,
+          memoRegex: n.memoRegex ?? null,
+          precision: n.precision ?? 0,
+          contract: n.contract ?? null,
         });
       }
     }


### PR DESCRIPTION
The first sync run failed on Prisma validation: `Network.precision` is required (also `memoName`, `memoRegex`, `contract` exist on the model). Whitelist now includes them, with values taken from Exolix (`precision: 8`, …).