### PR TITLE
Fall back to live Exolix API when the coin cache DB is unreachable

### DIFF
--- a/__tests__/exolix-map.test.ts
+++ b/__tests__/exolix-map.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFallbackData,
+  dedupeNetworkRows,
+  toCurrencyRows,
+  toNetworkRow,
+  type ExolixCurrency,
+} from "../lib/exolix-map";
+
+const xmr: ExolixCurrency = {
+  code: "XMR",
+  name: "Monero",
+  icon: "https://exolix.com/icons/xmr.png",
+  networks: [
+    {
+      network: "XMR",
+      name: "Monero",
+      shortName: "XMR",
+      isDefault: true,
+      memoNeeded: false,
+      precision: 12,
+      icon: "https://exolix.com/icons/xmr.png",
+      // Extra keys the Exolix API sends but the schema doesn't have:
+      platformTypes: ["MAIN"],
+      priority: 1,
+      privacy: true,
+    },
+  ],
+};
+
+const usdt: ExolixCurrency = {
+  code: "USDT",
+  name: "Tether",
+  networks: [
+    { network: "TRX", name: "Tron", precision: 6, contract: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t" },
+    { network: "ETH", name: "Ethereum", precision: 6, contract: "0xdAC17F958D2ee523a2206206994597C13D831ec7" },
+  ],
+};
+
+describe("toNetworkRow", () => {
+  it("keeps only schema fields and defaults missing ones", () => {
+    const row = toNetworkRow(xmr.networks![0]);
+    expect(row).toEqual({
+      network: "XMR",
+      name: "Monero",
+      shortName: "XMR",
+      addressRegex: null,
+      notes: null,
+      isDefault: true,
+      decimal: null,
+      icon: "https://exolix.com/icons/xmr.png",
+      blockExplorer: null,
+      depositMinAmount: null,
+      memoNeeded: false,
+      memoName: null,
+      memoRegex: null,
+      precision: 12,
+      contract: null,
+    });
+    expect(row).not.toHaveProperty("platformTypes");
+    expect(row).not.toHaveProperty("privacy");
+  });
+
+  it("defaults precision to 0 when absent", () => {
+    expect(toNetworkRow({ network: "BTC", name: "Bitcoin" }).precision).toBe(0);
+  });
+});
+
+describe("dedupeNetworkRows", () => {
+  it("dedupes networks by code, first occurrence wins", () => {
+    const rows = dedupeNetworkRows([
+      usdt,
+      { code: "USDC", name: "USD Coin", networks: [{ network: "ETH", name: "Ethereum (changed)" }] },
+    ]);
+    expect(rows.map((r) => r.network).sort()).toEqual(["ETH", "TRX"]);
+    expect(rows.find((r) => r.network === "ETH")?.name).toBe("Ethereum");
+  });
+
+  it("tolerates currencies without networks", () => {
+    expect(dedupeNetworkRows([{ code: "ABC", name: "No Nets" }])).toEqual([]);
+  });
+});
+
+describe("toCurrencyRows", () => {
+  it("emits one row per currency-network pair and drops unknown networks", () => {
+    const idByNetwork = new Map([["TRX", 7]]);
+    const rows = toCurrencyRows([usdt], idByNetwork);
+    expect(rows).toEqual([
+      { code: "USDT", name: "Tether", icon: null, notes: null, networkId: 7 },
+    ]);
+  });
+});
+
+describe("buildFallbackData", () => {
+  it("produces joinable networks and currencies with synthetic ids", () => {
+    const { networks, currencies } = buildFallbackData([xmr, usdt]);
+    // Networks sorted by code for stable ids
+    expect(networks.map((n) => n.network)).toEqual(["ETH", "TRX", "XMR"]);
+    // Every currency row points at an existing network id
+    const ids = new Set(networks.map((n) => n.id));
+    for (const c of currencies) expect(ids.has(c.networkId)).toBe(true);
+    // XMR resolves to the Monero network (this is what the frontend join does)
+    const xmrRow = currencies.find((c) => c.code === "XMR");
+    expect(xmrRow).toBeDefined();
+    expect(networks.find((n) => n.id === xmrRow!.networkId)?.network).toBe("XMR");
+    // USDT yields one row per network
+    expect(currencies.filter((c) => c.code === "USDT")).toHaveLength(2);
+  });
+
+  it("is deterministic for the same input", () => {
+    const a = buildFallbackData([usdt, xmr]);
+    const b = buildFallbackData([usdt, xmr]);
+    expect(a).toEqual(b);
+  });
+});

--- a/app/api/exolix/currency/route.ts
+++ b/app/api/exolix/currency/route.ts
@@ -1,14 +1,25 @@
-
 import { prisma } from "@/lib/prisma";
-import { NextRequest, NextResponse } from "next/server";
+import { getExolixFallback } from "@/lib/server/exolix-cache";
+import { NextResponse } from "next/server";
 
-export async function GET(req: NextRequest, res: NextResponse) {
+// The Postgres cache is the preferred source; when it is unreachable or
+// empty, fall back to a server-side cached pull from the Exolix API so the
+// coin list (XMR & co.) keeps working.
+export const dynamic = "force-dynamic";
+export const maxDuration = 30;
+
+export async function GET() {
   try {
     const currencies = await prisma.currency.findMany();
-
-    return NextResponse.json(currencies)
+    if (currencies.length > 0) return NextResponse.json(currencies);
+  } catch (error) {
+    console.warn("Exolix currency cache: database unavailable, using live fallback", error);
+  }
+  try {
+    const { currencies } = await getExolixFallback();
+    return NextResponse.json(currencies);
   } catch (error) {
     console.error("Error fetching currencies", error);
-    return NextResponse.json([])
+    return NextResponse.json([]);
   }
 }

--- a/app/api/exolix/network/route.ts
+++ b/app/api/exolix/network/route.ts
@@ -1,13 +1,24 @@
 import { prisma } from "@/lib/prisma";
-import { NextRequest, NextResponse } from "next/server";
+import { getExolixFallback } from "@/lib/server/exolix-cache";
+import { NextResponse } from "next/server";
 
-export async function GET(req: NextRequest, res: NextResponse) {
+// The Postgres cache is the preferred source; when it is unreachable or
+// empty, fall back to a server-side cached pull from the Exolix API.
+export const dynamic = "force-dynamic";
+export const maxDuration = 30;
+
+export async function GET() {
   try {
     const networks = await prisma.network.findMany();
-
-    return NextResponse.json(networks)
+    if (networks.length > 0) return NextResponse.json(networks);
+  } catch (error) {
+    console.warn("Exolix network cache: database unavailable, using live fallback", error);
+  }
+  try {
+    const { networks } = await getExolixFallback();
+    return NextResponse.json(networks);
   } catch (error) {
     console.error("Error fetching networks", error);
-    return NextResponse.json([])
+    return NextResponse.json([]);
   }
 }

--- a/app/api/exolix/sync/route.ts
+++ b/app/api/exolix/sync/route.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@/lib/prisma";
-import { exolixGet } from "@/lib/server/exolix";
+import { getAllExolixCurrencies } from "@/lib/server/exolix-cache";
+import { dedupeNetworkRows, toCurrencyRows } from "@/lib/exolix-map";
 import { NextRequest, NextResponse } from "next/server";
 
 // Re-syncs the Exolix networks/currencies cache in Postgres.
@@ -8,56 +9,6 @@ import { NextRequest, NextResponse } from "next/server";
 
 export const maxDuration = 60;
 
-type ExolixNetwork = {
-  coinNetworkId?: string;
-  network: string;
-  name: string;
-  shortName?: string | null;
-  addressRegex?: string | null;
-  notes?: string | null;
-  isDefault?: boolean;
-  decimal?: number | null;
-  icon?: string | null;
-  blockExplorer?: string | null;
-  depositMinAmount?: number | null;
-  memoNeeded?: boolean;
-  memoName?: string | null;
-  memoRegex?: string | null;
-  precision?: number;
-  contract?: string | null;
-};
-
-type ExolixCurrency = {
-  code: string;
-  name: string;
-  icon?: string | null;
-  notes?: string | null;
-  networks: ExolixNetwork[];
-};
-
-type CurrenciesPage = { count: number; data: ExolixCurrency[] };
-
-const PAGE_SIZE = 100;
-
-async function getAllCurrencies(): Promise<ExolixCurrency[]> {
-  const first = await exolixGet<CurrenciesPage>("/currencies", {
-    page: "1",
-    size: String(PAGE_SIZE),
-    withNetworks: "true",
-  });
-  const totalPages = Math.ceil(first.count / PAGE_SIZE);
-  const rest = await Promise.all(
-    Array.from({ length: totalPages - 1 }, (_, i) =>
-      exolixGet<CurrenciesPage>("/currencies", {
-        page: String(i + 2),
-        size: String(PAGE_SIZE),
-        withNetworks: "true",
-      }),
-    ),
-  );
-  return [first, ...rest].flatMap((p) => p.data);
-}
-
 async function handler(request: NextRequest) {
   const secret = process.env.CRON_SECRET;
   if (secret && request.headers.get("authorization") !== `Bearer ${secret}`) {
@@ -65,36 +16,12 @@ async function handler(request: NextRequest) {
   }
 
   try {
-    const currencies = await getAllCurrencies();
+    const currencies = await getAllExolixCurrencies();
 
     // Networks: dedupe by Exolix network code, insert missing ones.
-    // Whitelist only the schema fields — Exolix sends extra keys
-    // (contract, precision, platformTypes, ...) that Prisma would reject.
-    const networkByCode = new Map<string, Record<string, unknown>>();
-    for (const currency of currencies) {
-      for (const n of currency.networks) {
-        if (networkByCode.has(n.network)) continue;
-        networkByCode.set(n.network, {
-          network: n.network,
-          name: n.name,
-          shortName: n.shortName ?? null,
-          addressRegex: n.addressRegex ?? null,
-          notes: n.notes ?? null,
-          isDefault: n.isDefault ?? false,
-          decimal: n.decimal ?? null,
-          icon: n.icon ?? null,
-          blockExplorer: n.blockExplorer ?? null,
-          depositMinAmount: n.depositMinAmount ?? null,
-          memoNeeded: n.memoNeeded ?? false,
-          memoName: n.memoName ?? null,
-          memoRegex: n.memoRegex ?? null,
-          precision: n.precision ?? 0,
-          contract: n.contract ?? null,
-        });
-      }
-    }
+    const networkRows = dedupeNetworkRows(currencies);
     await prisma.network.createMany({
-      data: [...networkByCode.values()] as never,
+      data: networkRows as never,
       skipDuplicates: true,
     });
 
@@ -103,17 +30,7 @@ async function handler(request: NextRequest) {
     );
 
     // Currencies: full refresh (one row per currency-network pair).
-    const rows = currencies.flatMap((c) =>
-      c.networks
-        .map((n) => ({
-          code: c.code,
-          name: c.name,
-          icon: c.icon ?? null,
-          notes: c.notes ?? null,
-          networkId: idByNetwork.get(n.network),
-        }))
-        .filter((r): r is typeof r & { networkId: number } => !!r.networkId),
-    );
+    const rows = toCurrencyRows(currencies, idByNetwork);
     await prisma.$transaction([
       prisma.currency.deleteMany({}),
       prisma.currency.createMany({ data: rows }),
@@ -121,7 +38,7 @@ async function handler(request: NextRequest) {
 
     return NextResponse.json({
       ok: true,
-      networks: networkByCode.size,
+      networks: networkRows.length,
       currencies: rows.length,
     });
   } catch (error) {

--- a/lib/exolix-map.ts
+++ b/lib/exolix-map.ts
@@ -1,0 +1,111 @@
+// Pure mapping helpers for Exolix API payloads -> Dexifier cache shapes.
+// Kept free of server-only imports so it can be unit-tested and reused by
+// both the DB sync route and the live-API fallback cache.
+
+export type ExolixNetwork = {
+  coinNetworkId?: string;
+  network: string;
+  name: string;
+  shortName?: string | null;
+  addressRegex?: string | null;
+  notes?: string | null;
+  isDefault?: boolean;
+  decimal?: number | null;
+  icon?: string | null;
+  blockExplorer?: string | null;
+  depositMinAmount?: number | null;
+  memoNeeded?: boolean;
+  memoName?: string | null;
+  memoRegex?: string | null;
+  precision?: number;
+  contract?: string | null;
+  // Exolix sends more (platformTypes, priority, privacy, tokenRegex, ...)
+  // which Prisma would reject — toNetworkRow whitelists the schema fields.
+  [extra: string]: unknown;
+};
+
+export type ExolixCurrency = {
+  code: string;
+  name: string;
+  icon?: string | null;
+  notes?: string | null;
+  networks?: ExolixNetwork[];
+};
+
+export type NetworkRow = ReturnType<typeof toNetworkRow>;
+export type CurrencyRow = {
+  code: string;
+  name: string;
+  icon: string | null;
+  notes: string | null;
+  networkId: number;
+};
+
+// Whitelists exactly the fields of the Prisma Network model.
+export function toNetworkRow(n: ExolixNetwork) {
+  return {
+    network: n.network,
+    name: n.name ?? n.network,
+    shortName: n.shortName ?? null,
+    addressRegex: n.addressRegex ?? null,
+    notes: n.notes ?? null,
+    isDefault: n.isDefault ?? false,
+    decimal: n.decimal ?? null,
+    icon: n.icon ?? null,
+    blockExplorer: n.blockExplorer ?? null,
+    depositMinAmount: n.depositMinAmount ?? null,
+    memoNeeded: n.memoNeeded ?? false,
+    memoName: n.memoName ?? null,
+    memoRegex: n.memoRegex ?? null,
+    precision: n.precision ?? 0,
+    contract: n.contract ?? null,
+  };
+}
+
+// One Network row per Exolix network code, first occurrence wins.
+export function dedupeNetworkRows(currencies: ExolixCurrency[]): NetworkRow[] {
+  const byCode = new Map<string, NetworkRow>();
+  for (const currency of currencies) {
+    for (const n of currency.networks ?? []) {
+      if (!byCode.has(n.network)) byCode.set(n.network, toNetworkRow(n));
+    }
+  }
+  return [...byCode.values()];
+}
+
+// One Currency row per currency-network pair, linked via idByNetwork.
+// Pairs whose network is missing from the map are dropped.
+export function toCurrencyRows(
+  currencies: ExolixCurrency[],
+  idByNetwork: Map<string, number>,
+): CurrencyRow[] {
+  return currencies.flatMap((c) =>
+    (c.networks ?? [])
+      .map((n) => ({
+        code: c.code,
+        name: c.name,
+        icon: c.icon ?? null,
+        notes: c.notes ?? null,
+        networkId: idByNetwork.get(n.network),
+      }))
+      .filter((r): r is CurrencyRow => r.networkId != null),
+  );
+}
+
+// Builds the same response shapes the DB-backed routes return
+// (DNetwork[] / DCurrency[]), with deterministic synthetic ids so the
+// frontend join (`networks.find(n => n.id === currency.networkId)`) works.
+export function buildFallbackData(currencies: ExolixCurrency[]): {
+  networks: (NetworkRow & { id: number })[];
+  currencies: (CurrencyRow & { id: number })[];
+} {
+  const networks = dedupeNetworkRows(currencies)
+    .sort((a, b) => a.network.localeCompare(b.network))
+    .map((row, i) => ({ id: i + 1, ...row }));
+  const idByNetwork = new Map(networks.map((n) => [n.network, n.id]));
+  const rows = toCurrencyRows(currencies, idByNetwork).map((row, i) => ({
+    id: i + 1,
+    ...row,
+  }));
+  return { networks, currencies: rows };
+}

--- a/lib/server/exolix-cache.ts
+++ b/lib/server/exolix-cache.ts
@@ -1,0 +1,38 @@
+import "server-only";
+import { unstable_cache } from "next/cache";
+import { exolixGet } from "./exolix";
+import { buildFallbackData, type ExolixCurrency } from "../exolix-map";
+
+const PAGE_SIZE = 100;
+
+type CurrenciesPage = { count: number; data: ExolixCurrency[] };
+
+// Fetches every Exolix currency (with nested networks), page by page.
+export async function getAllExolixCurrencies(): Promise<ExolixCurrency[]> {
+  const first = await exolixGet<CurrenciesPage>("/currencies", {
+    page: "1",
+    size: String(PAGE_SIZE),
+    withNetworks: "true",
+  });
+  const totalPages = Math.ceil(first.count / PAGE_SIZE);
+  const rest = await Promise.all(
+    Array.from({ length: totalPages - 1 }, (_, i) =>
+      exolixGet<CurrenciesPage>("/currencies", {
+        page: String(i + 2),
+        size: String(PAGE_SIZE),
+        withNetworks: "true",
+      }),
+    ),
+  );
+  return [first, ...rest].flatMap((p) => p.data);
+}
+
+// Live-API stand-in for the Postgres cache, shared across serverless
+// instances via the Next data cache (revalidated every 6h). Lets the
+// currency/network routes keep serving coins (e.g. XMR) while the
+// database is unreachable or not yet seeded.
+export const getExolixFallback = unstable_cache(
+  async () => buildFallbackData(await getAllExolixCurrencies()),
+  ["exolix-db-fallback"],
+  { revalidate: 21600, tags: ["exolix-cache"] },
+);


### PR DESCRIPTION
## Problem
The Supabase Postgres behind `/api/exolix/currency` and `/api/exolix/network` is unreachable (pooler: `tenant/user ... not found`, project domain does not resolve). Both routes caught the error and returned `[]`, so every Exolix-only coin — including **XMR/Monero** — disappeared from the token selector.

## Fix
- `lib/exolix-map.ts`: shared pure mapping — schema-field whitelist, network dedupe by code, currency→network join, deterministic synthetic ids
- `lib/server/exolix-cache.ts`: paginated Exolix fetch wrapped in a 6h `unstable_cache`
- `/api/exolix/currency` + `/api/exolix/network`: serve Postgres first; if it errors or is empty, fall back to the cached live pull (force-dynamic, maxDuration 30)
- `/api/exolix/sync`: now reuses the same mapping so the whitelist cannot drift again (root cause of the `precision` incident)
- Unit tests for the mapping: 22/22 green; `next build` green

## Notes
The daily cron sync keeps failing until the Supabase project is restored or replaced — harmless. Once a DB is reachable again, one sync refills it and the DB path takes over automatically.