### PR TITLE
Real visual overhaul: animated aurora, neon frames, display type

### DIFF
--- a/app/_components/common/ambient-background.tsx
+++ b/app/_components/common/ambient-background.tsx
@@ -1,0 +1,14 @@
+// Full-screen animated ambient background: drifting aurora orbs in brand
+// colors, a perspective grid rising from the horizon, and a film-grain
+// overlay. Pure CSS animation, GPU-composited transforms only.
+export default function AmbientBackground() {
+  return (
+    <div aria-hidden className="fixed inset-0 -z-10 overflow-hidden bg-[#020a05]">
+      <div className="aurora-orb aurora-orb-1" />
+      <div className="aurora-orb aurora-orb-2" />
+      <div className="aurora-orb aurora-orb-3" />
+      <div className="dex-grid" />
+      <div className="dex-noise" />
+    </div>
+  );
+}

--- a/app/_components/dexifier/DexifierCard.tsx
+++ b/app/_components/dexifier/DexifierCard.tsx
@@ -24,7 +24,7 @@ import TooltipTemplate from "../common/tooltip-template";
 import SettingModal from "./SettingModal";
 import { cn } from "@/lib/utils";
 import { formatCryptoAmount } from "@/app/utils";
-import { ArrowDownUp } from "lucide-react";
+import { ArrowDownUp, Settings2 } from "lucide-react";
 
 const DexifierCard: React.FC = () => {
   // Use custom hook to get connected wallet details
@@ -80,36 +80,33 @@ const DexifierCard: React.FC = () => {
   return (
     <Card
       className={cn(
-        "w-full rounded-3xl text-white glass-card shadow-card",
-        isMobile ? "p-0" : "max-w-[650px] p-6 h-full"
+        "w-full text-white rounded-[28px] border border-primary/25 bg-[#041008]/85 backdrop-blur-2xl neon-frame",
+        isMobile ? "p-0 border-none bg-transparent shadow-none backdrop-blur-none before:hidden" : "max-w-[560px] p-8 h-full"
       )}
     >
       {!isMobile && (
         <>
-          <CardHeader className="p-4">
+          <CardHeader className="p-0 pb-6">
             <div className="h-auto bg-transparent flex w-full justify-between items-center">
-              <CardTitle>Swap</CardTitle>
+              <CardTitle className="font-display text-2xl font-bold uppercase tracking-[0.2em] text-glow">
+                Swap
+              </CardTitle>
               <SettingModal>
-                <Button className="bg-transparent hover:bg-transparent">
+                <Button className="bg-transparent hover:bg-transparent text-white/60 hover:text-primary transition-colors">
                   <TooltipTemplate content="Settings" className="!mb-1">
-                    <Image
-                      src={"/assets/icons/setting.png"}
-                      alt="button-icon"
-                      width={18}
-                      height={18}
-                    />
+                    <Settings2 size={20} />
                   </TooltipTemplate>
                 </Button>
               </SettingModal>
             </div>
           </CardHeader>
-          <Separator className="hidden md:block bg-[#AAA]/20" />
+          <Separator className="hidden md:block bg-gradient-to-r from-transparent via-primary/40 to-transparent" />
         </>
       )}
       <CardContent
         className={cn(
           "flex flex-col justify-around",
-          isMobile ? "px-5 py-[31px]" : "px-[31px] py-10"
+          isMobile ? "px-5 py-[31px]" : "px-0 py-8"
         )}
       >
         <div className="w-full flex flex-col justify-evenly gap-2">
@@ -148,7 +145,7 @@ const DexifierCard: React.FC = () => {
             type="number"
             id="tokenFrom"
             placeholder="0.0"
-            className="flex-1 border-none bg-transparent focus-visible:ring-0 focus-visible:outline-0 focus-visible:ring-offset-0 placeholder:text-white/30 pr-8 text-3xl md:text-4xl font-semibold tnum h-auto py-1"
+            className="flex-1 border-none bg-transparent focus-visible:ring-0 focus-visible:outline-0 focus-visible:ring-offset-0 placeholder:text-white/30 pr-8 text-4xl md:text-5xl font-semibold tnum h-auto py-1 caret-primary"
             value={amountFrom}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
               // e.target.value = parseFloat(e.target.value).toString();
@@ -161,11 +158,10 @@ const DexifierCard: React.FC = () => {
 
           {/* Reverse Swap Button */}
           <Button
-            variant="outline"
-            className="self-center mt-7 mb-1 h-[54px] w-[54px] rounded-full border border-primary/40 bg-black/40 p-1 text-primary transition-all duration-500 hover:rotate-180 hover:border-primary hover:shadow-neon"
+            className="self-center mt-7 mb-1 h-[54px] w-[54px] rounded-full border-none bg-primary p-1 text-black shadow-neon transition-all duration-500 hover:rotate-180 hover:shadow-neon-lg hover:brightness-110"
             onClick={reverseTokenPair}
           >
-            <ArrowDownUp size={24} />
+            <ArrowDownUp size={24} strokeWidth={2.5} />
           </Button>
 
           {/* Token To Section */}
@@ -175,7 +171,7 @@ const DexifierCard: React.FC = () => {
           <TokenInput
             type="number"
             id="tokenTo"
-            className="flex-1 border-none bg-transparent focus-visible:ring-0 focus-visible:outline-0 focus-visible:ring-offset-0 text-3xl md:text-4xl font-semibold tnum h-auto py-1"
+            className="flex-1 border-none bg-transparent focus-visible:ring-0 focus-visible:outline-0 focus-visible:ring-offset-0 text-4xl md:text-5xl font-semibold tnum h-auto py-1"
             disabled
             token={tokenTo}
             setToken={setTokenTo}
@@ -184,12 +180,12 @@ const DexifierCard: React.FC = () => {
         </div>
       </CardContent>
       {!isMobile && (
-        <CardFooter className="text-base md:text-xl p-0">
+        <CardFooter className="text-base md:text-xl p-0 pt-6">
           {/* Footer Section: Handles the swap confirmation or wallet connection */}
           {!selectedRoute?.hasOwnProperty('outputAmount') ? (
             <Button
               variant="neon"
-              className="w-full md:max-w-[75%] lg:max-w-[67%] h-14 mx-auto text-xl"
+              className="btn-sheen w-full h-16 text-xl font-extrabold uppercase tracking-widest"
               disabled={!selectedRoute || state === DEXIFIER_STATE.PENDING || (!!swapData && state < DEXIFIER_STATE.PROCESSING)}
               onClick={() => {
                 // After a swap ends (success/failure) offer a reset; during
@@ -206,7 +202,7 @@ const DexifierCard: React.FC = () => {
           ) : !isWalletConnected ? (
             <WalletConnectModal>
               <Button
-                className="h-14 w-3/4 lg:w-[67%] mx-auto"
+                className="btn-sheen w-full h-16 text-xl font-extrabold uppercase tracking-widest"
                 variant="neon"
               >
                 Connect Wallet
@@ -216,7 +212,7 @@ const DexifierCard: React.FC = () => {
             <ConfirmModal>
               <Button
                 variant="neon"
-                className="w-full md:max-w-[75%] lg:max-w-[67%] h-14 mx-auto text-xl"
+                className="btn-sheen w-full h-16 text-xl font-extrabold uppercase tracking-widest"
                 disabled={!selectedRoute || !!swapData}
               >
                 Swap Now

--- a/app/_components/dexifier/RouteCard.tsx
+++ b/app/_components/dexifier/RouteCard.tsx
@@ -409,13 +409,15 @@ const RouteCard = () => {
   return (
     <Card
       className={cn(
-        "h-full flex flex-col w-full glass-card shadow-card p-6 rounded-3xl text-white",
-        isMobile ? "p-5" : "max-w-[650px] p-6"
+        "h-full flex flex-col w-full rounded-[28px] border border-primary/25 bg-[#041008]/85 backdrop-blur-2xl neon-frame text-white",
+        isMobile ? "p-5 border-none bg-transparent shadow-none backdrop-blur-none before:hidden" : "max-w-[650px] p-6"
       )}
     >
       <CardHeader className="md:p-4 py-4 px-0">
         <div className="h-auto bg-transparent flex w-full justify-between gap-4">
-          <CardTitle>Routes</CardTitle>
+          <CardTitle className="font-display text-2xl font-bold uppercase tracking-[0.2em] text-glow">
+            Routes
+          </CardTitle>
           <RadioGroup
             defaultValue={FILTERS[0]}
             onValueChange={(value) => setFilter(value)}
@@ -490,7 +492,7 @@ const RouteCard = () => {
                         value={index.toString()}
                         id={index.toString()}
                         key={index}
-                        className="w-full rounded-2xl border border-white/10 bg-white/[0.03] p-4 transition duration-300 hover:border-primary/40 hover:bg-primary/5 data-[state=checked]:border-primary data-[state=checked]:bg-primary/10 data-[state=checked]:shadow-neon-sm"
+                        className="w-full rounded-2xl border border-white/10 bg-white/[0.03] p-4 transition duration-300 hover:border-primary/40 hover:bg-primary/5 data-[state=checked]:border-primary data-[state=checked]:bg-primary/10 data-[state=checked]:shadow-neon"
                       >
                         {'outputAmount' in route ? (
                           rangoRoute(route, index === 0)

--- a/app/_components/navbar/MainNavbar.tsx
+++ b/app/_components/navbar/MainNavbar.tsx
@@ -84,8 +84,8 @@ const MainNavbar = () => {
     <header
       className={cn(scrolled ? '' : 'bg-transparent', 'w-screen transition fixed top-0 z-50 duration-300')}
     >
-      <div className={`max-w-[86rem] mx-auto px-2 sm:px-6 lg:px-8 pt-12 pb-4`}>
-        <div className="relative flex items-center justify-center md:justify-between">
+      <div className={`max-w-[86rem] mx-auto px-2 sm:px-6 lg:px-8 pt-5 pb-4`}>
+        <div className="relative flex items-center justify-center md:justify-between rounded-full border border-white/10 bg-black/40 backdrop-blur-xl px-6 py-3">
           {/* Logo */}
           <div className="absolute inset-0 flex items-center md:hidden">
             <button
@@ -131,7 +131,7 @@ const MainNavbar = () => {
           {/* Logo (hidden on small screens) */}
           <Link href="/">
             <Image
-              className="md:w-[285px] w-[200px]"
+              className="md:w-[220px] w-[180px]"
               src="/assets/logo.png"
               alt="Logo"
               width={285}
@@ -139,22 +139,22 @@ const MainNavbar = () => {
             />
           </Link>
           {/* Navigations */}
-          <div className={`hidden md:flex space-x-5`}>
+          <div className={`hidden md:flex items-center space-x-6`}>
             {NAVIGATIONS.map((link, index) => (
               <Link
                 key={index}
                 href={link.path}
                 target={link.target}
-                className={cn(pathname === link.path ? 'text-primary' : 'text-white', 'px-3 py-2 text-[1.375rem] transition-colors duration-300 hover:text-primary')}
+                className={cn(pathname === link.path ? 'text-primary' : 'text-white/80', 'px-1 py-2 text-sm font-semibold uppercase tracking-widest transition-colors duration-300 hover:text-primary')}
               >
                 {link.text}
               </Link>
             ))}
             {(!connectedWallets.length ?
               <WalletConnectModal>
-                <button className="flex text-[1.075rem] bg-primary rounded-full py-2 px-4 gap-2 items-center justify-center hover:opacity-80">
+                <button className="flex text-[1.075rem] bg-primary rounded-full py-2 px-4 gap-2 items-center justify-center shadow-neon transition hover:shadow-neon-lg hover:brightness-110">
                   <BiSolidWallet className="size-6 text-black" />
-                  <span className="text-black">Connect Wallet</span>
+                  <span className="text-black font-semibold">Connect Wallet</span>
                 </button>
               </WalletConnectModal>
               :

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,17 +4,25 @@
 
 body {
   color: white;
-  background-color: #030a06;
+  background-color: #020a05;
 }
 
-/* ---------- Dexifier design tokens (neon-degen system) ---------- */
+/* ---------- Dexifier neon-degen design system ---------- */
 
 /* Tabular figures for all amounts — stops number jitter on quote updates */
 .tnum {
   font-variant-numeric: tabular-nums;
 }
 
-/* Shared glass surface for the main cards */
+.font-display {
+  font-family: var(--font-display), inherit;
+}
+
+.text-glow {
+  text-shadow: 0 0 18px rgba(19, 241, 135, 0.45);
+}
+
+/* Shared glass surface for panels */
 .glass-card {
   background: linear-gradient(
     165deg,
@@ -27,17 +35,146 @@ body {
   -webkit-backdrop-filter: blur(18px);
 }
 
-/* Subtle static ambient glow (replaces the busy background image) */
-.bg-ambient {
-  background:
-    radial-gradient(55% 45% at 12% 0%, rgba(19, 241, 135, 0.13), transparent 62%),
-    radial-gradient(45% 40% at 88% 12%, rgba(0, 224, 255, 0.06), transparent 60%),
-    radial-gradient(65% 55% at 50% 105%, rgba(15, 189, 107, 0.11), transparent 66%),
-    #030a06;
+/* ---- Animated aurora background ---- */
+.aurora-orb {
+  position: absolute;
+  border-radius: 9999px;
+  filter: blur(110px);
+  mix-blend-mode: screen;
+  will-change: transform;
+}
+.aurora-orb-1 {
+  width: 55vw;
+  height: 55vw;
+  left: -15vw;
+  top: -22vw;
+  background: radial-gradient(circle at 40% 40%, rgba(19, 241, 135, 0.5), transparent 62%);
+  animation: aurora-drift-1 26s ease-in-out infinite alternate;
+}
+.aurora-orb-2 {
+  width: 44vw;
+  height: 44vw;
+  right: -12vw;
+  top: -10vw;
+  background: radial-gradient(circle at 60% 40%, rgba(0, 224, 255, 0.3), transparent 60%);
+  animation: aurora-drift-2 32s ease-in-out infinite alternate;
+}
+.aurora-orb-3 {
+  width: 62vw;
+  height: 62vw;
+  left: 18vw;
+  bottom: -38vw;
+  background: radial-gradient(circle at 50% 50%, rgba(15, 189, 107, 0.38), transparent 64%);
+  animation: aurora-drift-3 38s ease-in-out infinite alternate;
+}
+@keyframes aurora-drift-1 {
+  to {
+    transform: translate(9vw, 7vh) scale(1.14);
+  }
+}
+@keyframes aurora-drift-2 {
+  to {
+    transform: translate(-8vw, 9vh) scale(1.1);
+  }
+}
+@keyframes aurora-drift-3 {
+  to {
+    transform: translate(-6vw, -7vh) scale(1.16);
+  }
 }
 
-.text-glow {
-  text-shadow: 0 0 18px rgba(19, 241, 135, 0.45);
+/* Perspective grid fading in from the horizon */
+.dex-grid {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(19, 241, 135, 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(19, 241, 135, 0.08) 1px, transparent 1px);
+  background-size: 60px 60px;
+  mask-image: radial-gradient(ellipse 90% 55% at 50% 115%, black 25%, transparent 72%);
+  -webkit-mask-image: radial-gradient(ellipse 90% 55% at 50% 115%, black 25%, transparent 72%);
+  transform: perspective(650px) rotateX(38deg) scale(2.4);
+  transform-origin: bottom;
+}
+
+/* Film grain so the glows don't look like flat vector blobs */
+.dex-noise {
+  position: absolute;
+  inset: 0;
+  opacity: 0.05;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+}
+
+/* ---- Animated neon frame (rotating conic border) ---- */
+@property --dex-angle {
+  syntax: "<angle>";
+  initial-value: 0deg;
+  inherits: false;
+}
+.neon-frame {
+  position: relative;
+  box-shadow:
+    0 0 90px rgba(19, 241, 135, 0.13),
+    0 24px 70px rgba(0, 0, 0, 0.6);
+}
+.neon-frame::before {
+  content: "";
+  position: absolute;
+  inset: -1px;
+  border-radius: inherit;
+  padding: 1.5px;
+  background: conic-gradient(
+    from var(--dex-angle),
+    rgba(19, 241, 135, 0) 0%,
+    rgba(19, 241, 135, 0.95) 10%,
+    rgba(0, 224, 255, 0.55) 20%,
+    rgba(19, 241, 135, 0) 32%,
+    rgba(19, 241, 135, 0) 100%
+  );
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  mask-composite: exclude;
+  animation: dex-spin 6s linear infinite;
+  pointer-events: none;
+}
+@keyframes dex-spin {
+  to {
+    --dex-angle: 360deg;
+  }
+}
+
+/* ---- CTA sheen sweep ---- */
+.btn-sheen {
+  position: relative;
+  overflow: hidden;
+}
+.btn-sheen::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    110deg,
+    transparent 30%,
+    rgba(255, 255, 255, 0.35) 50%,
+    transparent 70%
+  );
+  transform: translateX(-130%);
+  animation: sheen-sweep 3.5s ease-in-out infinite;
+  pointer-events: none;
+}
+.btn-sheen:disabled::after {
+  display: none;
+}
+@keyframes sheen-sweep {
+  55%,
+  100% {
+    transform: translateX(130%);
+  }
 }
 
 input[type="number"] {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,13 +2,14 @@ import "./globals.css";
 import React from "react";
 import MainNavbar from "./_components/navbar/MainNavbar";
 import type { Metadata, Viewport } from "next";
-import { Plus_Jakarta_Sans } from "next/font/google";
+import { Plus_Jakarta_Sans, Space_Grotesk } from "next/font/google";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import Analytics from "./Analytics";
 import ProvidersWrapper from "./_components/providers-wrapper";
 
 const inter = Plus_Jakarta_Sans({ subsets: ["latin"] });
+const display = Space_Grotesk({ subsets: ["latin"], variable: "--font-display" });
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://www.dexifier.com"),
@@ -63,7 +64,7 @@ export default function RootLayout({
         <link rel="dns-prefetch" href="https://exolix.com" />
         <Analytics />
       </head>
-      <body id="root" className={inter.className}>
+      <body id="root" className={`${inter.className} ${display.variable}`}>
         <ProvidersWrapper>
           <MainNavbar />
           {children}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ import { AnimatePresence, motion } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import AddressesCard from "./_components/dexifier/AddressCard";
+import AmbientBackground from "./_components/common/ambient-background";
 import { Loader2 } from "lucide-react";
 
 export default function SwapPage() {
@@ -27,16 +28,17 @@ export default function SwapPage() {
   return (
     <main
       className={cn(
-        "relative min-h-screen pt-32 bg-ambient",
-        isMobile ? "px-8" : "px-4"
+        "relative min-h-screen",
+        isMobile ? "px-8 pt-28" : "px-4"
       )}
     >
+      <AmbientBackground />
       <section
         className={cn(
           "flex justify-center",
           isMobile
             ? "h-full flex-col gap-8"
-            : "flex-row flex-wrap gap-5 h-[560px] items-stretch m-4 mt-32"
+            : "flex-row flex-wrap gap-8 h-[560px] items-stretch min-h-screen content-center -mt-10"
         )}
       >
         <DexifierCard />

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -15,7 +15,7 @@ const buttonVariants = cva(
           "bg-slate-900 text-slate-50 hover:bg-slate-900/90 dark:bg-slate-50 dark:text-slate-900 dark:hover:bg-slate-50/90",
         primary:
           "w-full bg-primary hover:bg-primary-dark transition duration-300 text-black rounded-md font-semibold text-base xl:text-xl",
-        neon: "w-full bg-gradient-to-r from-primary to-accent text-black font-bold rounded-2xl shadow-neon hover:shadow-neon-lg hover:brightness-110 active:scale-[0.99] transition-all duration-300 disabled:shadow-none disabled:saturate-50",
+        neon: "w-full bg-gradient-to-r from-primary to-accent text-black font-bold rounded-2xl shadow-neon hover:shadow-neon-lg hover:brightness-110 active:scale-[0.99] transition-all duration-300 disabled:bg-none disabled:bg-white/5 disabled:text-white/40 disabled:border disabled:border-white/10 disabled:shadow-none disabled:opacity-100",
         secondary: `bg-white text-black font-bold text-base ${inter.className}`,
         destructive:
           "bg-red-500 text-slate-50 hover:bg-red-500/90 dark:bg-red-900 dark:text-slate-50 dark:hover:bg-red-900/90",


### PR DESCRIPTION
The actual redesign — replaces the stage-1 polish pass.

- **AmbientBackground**: three drifting aurora orbs (green/cyan/emerald, screen-blended), a perspective grid rising from the horizon, film grain — animated, GPU-composited
- **neon-frame**: rotating conic-gradient border + deep outer glow on the swap and routes cards
- **DexifierCard**: 560px centerpiece, deep glass interior, Space Grotesk display title, text-5xl tabular amounts with neon caret, filled neon flip button, full-width h-16 uppercase CTA with sheen sweep
- **Disabled CTA**: dark glass (kills the muddy desaturated gradient)
- **Navbar**: floating glass pill, uppercase micro links, glowing connect button
- Content centered in the viewport over the aurora

tsc clean, 39/39 tests, 0 lint errors.