### PR TITLE
Fix card overflow: size to content, center with navbar clearance

### DIFF
--- a/app/_components/dexifier/DexifierCard.tsx
+++ b/app/_components/dexifier/DexifierCard.tsx
@@ -81,7 +81,7 @@ const DexifierCard: React.FC = () => {
     <Card
       className={cn(
         "w-full text-white rounded-[28px] border border-primary/25 bg-[#041008]/85 backdrop-blur-2xl neon-frame",
-        isMobile ? "p-0 border-none bg-transparent shadow-none backdrop-blur-none before:hidden" : "max-w-[560px] p-8 h-full"
+        isMobile ? "p-0 border-none bg-transparent shadow-none backdrop-blur-none before:hidden" : "max-w-[560px] p-8"
       )}
     >
       {!isMobile && (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -38,7 +38,7 @@ export default function SwapPage() {
           "flex justify-center",
           isMobile
             ? "h-full flex-col gap-8"
-            : "flex-row flex-wrap gap-8 h-[560px] items-stretch min-h-screen content-center -mt-10"
+            : "flex-row flex-wrap gap-8 items-stretch min-h-screen content-center px-4 pt-28 pb-16"
         )}
       >
         <DexifierCard />


### PR DESCRIPTION
The larger overhaul card (~700px) overflowed the fixed 560px section — titles clipped behind the navbar and the neon frame was cut at the viewport bottom. Section now sizes to content, cards center with pt-28/pb-16 clearance; routes card keeps its internal scroll.