### PR TITLE
Brighter aurora orbs + animation pass + stage 3 modal restyle

### DIFF
--- a/app/_components/common/search.tsx
+++ b/app/_components/common/search.tsx
@@ -5,13 +5,13 @@ const Search = ({
   ...props
 }: InputHTMLAttributes<HTMLInputElement>) => {
   return (
-    <div className="pe-[1rem] flex items-center gap-2 bg-black/10 rounded-xl border border-separator">
+    <div className="pe-[1rem] flex items-center gap-2 bg-black/40 rounded-2xl border border-white/10 transition duration-300 hover:border-white/20 focus-within:border-primary/60 focus-within:shadow-neon-sm">
       <input
-        className="ps-[1rem] py-2.5 w-full bg-transparent text-white border-none outline-none"
+        className="ps-[1rem] py-2.5 w-full bg-transparent text-white border-none outline-none placeholder:text-white/40"
         placeholder="Search"
         {...props}
       />
-      <IoSearchSharp className="font-bold text-[2rem] text-primary" />
+      <IoSearchSharp className="font-bold text-[1.5rem] text-primary" />
     </div>
   );
 };

--- a/app/_components/dexifier/AddressCard.tsx
+++ b/app/_components/dexifier/AddressCard.tsx
@@ -262,9 +262,9 @@ const AddressesCard = () => {
   };
 
   return (
-    <Card className="flex flex-col max-w-[650px] md:min-h-[540px] w-full h-full md:bg-modal/5 bg-primary/10 border border-[#AAA]/20 backdrop-blur-lg md:p-6 md:rounded-[2rem] rounded-[20px] shadow-lg text-white">
+    <Card className="flex flex-col max-w-[650px] md:min-h-[540px] w-full h-full bg-[#041008]/85 md:backdrop-blur-2xl md:p-6 rounded-[28px] border border-primary/25 md:neon-frame animate-rise text-white">
       <CardHeader className="md:p-4 md:pt-0 px-4 pt-6">
-        <CardTitle className="md:text-2xl text-lg font-semibold">
+        <CardTitle className="md:text-2xl text-lg font-display font-bold uppercase tracking-[0.15em] text-glow">
           {swapStatus ? (
             <span className="text-primary uppercase">
               Confirming Transaction

--- a/app/_components/dexifier/ConfirmModal.tsx
+++ b/app/_components/dexifier/ConfirmModal.tsx
@@ -259,7 +259,7 @@ const ConfirmModal: React.FC<PropsWithChildren> = (props) => {
       }}
     >
       <DialogTrigger asChild>{props.children}</DialogTrigger>
-      <DialogContent className="w-[30rem] bg-transparent max-h-[90vh] max-w-[90vw] p-6 bg-gradient-to-b from-black to-[#042214] border border-separator !rounded-3xl">
+      <DialogContent className="w-[30rem] bg-transparent max-h-[90vh] max-w-[90vw] p-6 bg-[#041008]/95 backdrop-blur-2xl border border-primary/25 shadow-neon-lg !rounded-3xl">
         <DialogHeader>
           <div className="flex flex-row justify-between p-2">
             <DialogTitle className="text-2xl">Confirm</DialogTitle>

--- a/app/_components/dexifier/DexifierCard.tsx
+++ b/app/_components/dexifier/DexifierCard.tsx
@@ -80,7 +80,7 @@ const DexifierCard: React.FC = () => {
   return (
     <Card
       className={cn(
-        "w-full text-white rounded-[28px] border border-primary/25 bg-[#041008]/85 backdrop-blur-2xl neon-frame",
+        "w-full text-white rounded-[28px] border border-primary/25 bg-[#041008]/85 backdrop-blur-2xl neon-frame animate-rise",
         isMobile ? "p-0 border-none bg-transparent shadow-none backdrop-blur-none before:hidden" : "max-w-[560px] p-8"
       )}
     >
@@ -158,7 +158,7 @@ const DexifierCard: React.FC = () => {
 
           {/* Reverse Swap Button */}
           <Button
-            className="self-center mt-7 mb-1 h-[54px] w-[54px] rounded-full border-none bg-primary p-1 text-black shadow-neon transition-all duration-500 hover:rotate-180 hover:shadow-neon-lg hover:brightness-110"
+            className="self-center mt-7 mb-1 h-[54px] w-[54px] rounded-full border-none bg-primary p-1 text-black shadow-neon animate-pulse-glow transition-all duration-500 hover:rotate-180 hover:shadow-neon-lg hover:brightness-110"
             onClick={reverseTokenPair}
           >
             <ArrowDownUp size={24} strokeWidth={2.5} />
@@ -185,7 +185,7 @@ const DexifierCard: React.FC = () => {
           {!selectedRoute?.hasOwnProperty('outputAmount') ? (
             <Button
               variant="neon"
-              className="btn-sheen w-full h-16 text-xl font-extrabold uppercase tracking-widest"
+              className="btn-sheen w-full h-16 text-xl font-extrabold uppercase tracking-widest enabled:animate-pulse-glow"
               disabled={!selectedRoute || state === DEXIFIER_STATE.PENDING || (!!swapData && state < DEXIFIER_STATE.PROCESSING)}
               onClick={() => {
                 // After a swap ends (success/failure) offer a reset; during

--- a/app/_components/dexifier/DexifierDetailRango.tsx
+++ b/app/_components/dexifier/DexifierDetailRango.tsx
@@ -115,7 +115,7 @@ const DexifierDetailRango = () => {
   };
 
   return selectedRoute && (
-    <Card className="max-w-[650px] min-h-[540px] w-full h-full bg-modal/5 border border-[#AAA]/20 backdrop-blur-lg p-2 rounded-[2rem] shadow-lg text-white">
+    <Card className="max-w-[650px] min-h-[540px] w-full h-full bg-[#041008]/85 backdrop-blur-2xl p-2 rounded-[28px] border border-primary/25 neon-frame animate-rise text-white">
       <CardHeader className="flex flex-row justify-between items-center">
         <h1 className="text-2xl">Swap Details</h1>
         <button

--- a/app/_components/dexifier/RouteCard.tsx
+++ b/app/_components/dexifier/RouteCard.tsx
@@ -409,7 +409,7 @@ const RouteCard = () => {
   return (
     <Card
       className={cn(
-        "h-full flex flex-col w-full rounded-[28px] border border-primary/25 bg-[#041008]/85 backdrop-blur-2xl neon-frame text-white",
+        "h-full flex flex-col w-full rounded-[28px] border border-primary/25 bg-[#041008]/85 backdrop-blur-2xl neon-frame animate-rise text-white",
         isMobile ? "p-5 border-none bg-transparent shadow-none backdrop-blur-none before:hidden" : "max-w-[650px] p-6"
       )}
     >
@@ -492,7 +492,8 @@ const RouteCard = () => {
                         value={index.toString()}
                         id={index.toString()}
                         key={index}
-                        className="w-full rounded-2xl border border-white/10 bg-white/[0.03] p-4 transition duration-300 hover:border-primary/40 hover:bg-primary/5 data-[state=checked]:border-primary data-[state=checked]:bg-primary/10 data-[state=checked]:shadow-neon"
+                        style={{ animationDelay: `${index * 70}ms` }}
+                        className="route-row-enter w-full rounded-2xl border border-white/10 bg-white/[0.03] p-4 transition duration-300 hover:border-primary/40 hover:bg-primary/5 data-[state=checked]:border-primary data-[state=checked]:bg-primary/10 data-[state=checked]:shadow-neon"
                       >
                         {'outputAmount' in route ? (
                           rangoRoute(route, index === 0)

--- a/app/_components/dexifier/SettingModal/HistoryModal.tsx
+++ b/app/_components/dexifier/SettingModal/HistoryModal.tsx
@@ -90,7 +90,7 @@ const HistoryModal: React.FC<PropsWithChildren> = ({ children, ...props }) => {
   return (
     <Dialog>
       <DialogTrigger asChild>{children}</DialogTrigger>
-      <DialogContent className="flex flex-col sm:max-w-md bg-transparent max-h-[90vh] max-w-[90vw] p-4 md:p-6 bg-gradient-to-b from-black to-[#042214] border border-separator !rounded-3xl">
+      <DialogContent className="flex flex-col sm:max-w-md bg-transparent max-h-[90vh] max-w-[90vw] p-4 md:p-6 bg-[#041008]/95 backdrop-blur-2xl border border-primary/25 shadow-neon-lg !rounded-3xl">
         <DialogHeader className="flex flex-row justify-between">
           {/* Dialog header with title and close button */}
           <DialogTitle className="text-2xl">History</DialogTitle>

--- a/app/_components/dexifier/SettingModal/SwapperModal.tsx
+++ b/app/_components/dexifier/SettingModal/SwapperModal.tsx
@@ -42,7 +42,7 @@ const SwapperModal: React.FC<PropsWithChildren<SwapperModalProps>> = ({ children
   return (
     <Dialog>
       <DialogTrigger asChild>{children}</DialogTrigger>
-      <DialogContent className="flex flex-col sm:max-w-md bg-transparent max-h-[90vh] max-w-[90vw] p-4 md:p-6 bg-gradient-to-b from-black to-[#042214] border border-separator !rounded-3xl">
+      <DialogContent className="flex flex-col sm:max-w-md bg-transparent max-h-[90vh] max-w-[90vw] p-4 md:p-6 bg-[#041008]/95 backdrop-blur-2xl border border-primary/25 shadow-neon-lg !rounded-3xl">
         <DialogHeader className="flex flex-row justify-between">
           <DialogTitle className="text-2xl">{props.title}</DialogTitle>
           <DialogClose>

--- a/app/_components/dexifier/SettingModal/index.tsx
+++ b/app/_components/dexifier/SettingModal/index.tsx
@@ -34,7 +34,7 @@ const SettingModal: React.FC<PropsWithChildren> = ({ children, ...props }) => {
     title: string | ReactNode,
     endingContent: ReactNode
   ) => (
-    <div className="py-4 flex items-center justify-between hover:bg-black/30 hover:border-primary border-b border-separator text-lg cursor-pointer transition-colors duration-300">
+    <div className="py-4 flex items-center justify-between hover:bg-black/30 hover:border-primary border-b border-white/10 text-lg cursor-pointer transition-colors duration-300">
       <div className="flex items-center gap-2.5">
         {image}
         <span>{title}</span>
@@ -46,7 +46,7 @@ const SettingModal: React.FC<PropsWithChildren> = ({ children, ...props }) => {
   return (
     <Dialog>
       <DialogTrigger asChild>{children}</DialogTrigger>
-      <DialogContent className="sm:max-w-md bg-transparent max-h-[90vh] max-w-[90vw] p-4 md:p-6 bg-gradient-to-b from-black to-[#042214] border border-separator !rounded-3xl">
+      <DialogContent className="sm:max-w-md bg-transparent max-h-[90vh] max-w-[90vw] p-4 md:p-6 bg-[#041008]/95 backdrop-blur-2xl border border-primary/25 shadow-neon-lg !rounded-3xl">
         <DialogHeader className="flex flex-row justify-between">
           {/* Dialog header with title and close button */}
           <DialogTitle className="text-2xl">Settings</DialogTitle>
@@ -75,7 +75,7 @@ const SettingModal: React.FC<PropsWithChildren> = ({ children, ...props }) => {
           <div id="slippage" className="flex flex-wrap items-center justify-between my-4 gap-3">
             {PERCENTAGES.map((percentage, index) => (
               <Button key={index} variant="outline"
-                className={cn(settings.slippage === percentage ? "border-primary text-primary" : "border-separator text-white",
+                className={cn(settings.slippage === percentage ? "border-primary text-primary" : "border-white/10 text-white",
                   "border hover:bg-inherit hover:border-primary-dark hover:text-primary-dark h-[3.375rem] w-1/6 text-base rounded-[.5625rem]"
                 )}
                 onClick={() => {
@@ -90,7 +90,7 @@ const SettingModal: React.FC<PropsWithChildren> = ({ children, ...props }) => {
             ))}
             <Input
               type="number"
-              className={cn(PERCENTAGES.includes(settings.slippage) ? "border-separator text-white" : "border-primary text-primary",
+              className={cn(PERCENTAGES.includes(settings.slippage) ? "border-white/10 text-white" : "border-primary text-primary",
                 "text-center border hover:border-primary-dark focus-visible:ring-0 focus-visible:ring-offset-0 bg-transparent rounded-[.5625rem] w-1/4 h-[3.375rem] transition-colors duration-300")}
               value={settings.slippage}
               placeholder="custom"

--- a/app/_components/dexifier/TokenModal/BlockchainModal.tsx
+++ b/app/_components/dexifier/TokenModal/BlockchainModal.tsx
@@ -49,7 +49,7 @@ const BlockchainModal: React.FC<PropsWithChildren<BlockchainModalProps>> = ({ ch
       <DialogTrigger asChild>{children}</DialogTrigger>
 
       {/* Modal content */}
-      <DialogContent className="flex flex-col sm:max-w-md bg-transparent max-h-[90vh] max-w-[90vw] p-4 md:p-6 bg-gradient-to-b from-black to-[#042214] border border-separator !rounded-3xl">
+      <DialogContent className="flex flex-col sm:max-w-md bg-transparent max-h-[90vh] max-w-[90vw] p-4 md:p-6 bg-[#041008]/95 backdrop-blur-2xl border border-primary/25 shadow-neon-lg !rounded-3xl">
         <DialogHeader className="flex flex-row justify-between">
           <DialogTitle className="text-2xl">Blockchains</DialogTitle>
           <DialogClose>
@@ -69,7 +69,7 @@ const BlockchainModal: React.FC<PropsWithChildren<BlockchainModalProps>> = ({ ch
             return (
               <DialogClose
                 key={index}
-                className="w-full flex items-center justify-between border-b border-separator hover:opacity-80 p-2"
+                className="w-full flex items-center justify-between border-b border-white/10 hover:opacity-80 p-2"
                 onClick={() => {
                   rememberChain(blockchain.name); // Track usage for future ordering
                   setSelectedBlockchain(blockchain);

--- a/app/_components/dexifier/TokenModal/Blockchains.tsx
+++ b/app/_components/dexifier/TokenModal/Blockchains.tsx
@@ -42,8 +42,8 @@ const Blockchains: React.FC<BlockchainsProps> = ({ selectedBlockchain, setSelect
           >
             <div
               className={cn(
-                'px-1 py-2.5 flex items-center justify-center border rounded-3xl bg-transparent hover:bg-white/5 transition-colors duration-300 cursor-pointer',
-                selectedBlockchain?.displayName === blockchain.displayName ? "border-primary" : "border-separator" // Conditional border color for selected blockchain
+                'group px-1 py-2.5 flex items-center justify-center border rounded-3xl bg-transparent hover:bg-primary/10 hover:shadow-neon-sm hover:border-primary/60 hover:scale-[1.06] transition-all duration-300 cursor-pointer',
+                selectedBlockchain?.displayName === blockchain.displayName ? "border-primary shadow-neon-sm" : "border-white/15" // Conditional border color for selected blockchain
               )}
               onClick={() => {
                 rememberChain(blockchain.name); // Track usage for future ordering
@@ -66,7 +66,7 @@ const Blockchains: React.FC<BlockchainsProps> = ({ selectedBlockchain, setSelect
         selectedBlockchain={selectedBlockchain}
         setSelectedBlockchain={setSelectedBlockchain}
       >
-        <div className="px-1 py-2.5 flex items-center justify-center border rounded-3xl bg-transparent hover:bg-white/5 transition-colors duration-300 cursor-pointer border-separator">
+        <div className="px-1 py-2.5 flex items-center justify-center border rounded-3xl bg-transparent hover:bg-white/5 transition-colors duration-300 cursor-pointer border-white/10">
           <h3 className="text-sm text-center">View More</h3> {/* Text to show the View More option */}
         </div>
       </BlockchainModal>

--- a/app/_components/dexifier/TokenModal/index.tsx
+++ b/app/_components/dexifier/TokenModal/index.tsx
@@ -99,22 +99,22 @@ const TokenModal: React.FC<PropsWithChildren<TokenModalProps>> = ({ children, se
     <Dialog>
       {/* Trigger to open the dialog */}
       <DialogTrigger asChild>{children}</DialogTrigger>
-      <DialogContent className="flex flex-col sm:max-w-md bg-transparent max-h-[90vh] max-w-[90vw] p-4 md:p-6 bg-gradient-to-b from-black to-[#042214] border border-separator !rounded-3xl">
+      <DialogContent className="flex flex-col sm:max-w-md max-h-[90vh] max-w-[90vw] p-4 md:p-6 bg-[#041008]/95 backdrop-blur-2xl border border-primary/25 shadow-neon-lg !rounded-3xl">
         <DialogHeader className="flex flex-row justify-between">
           {/* Dialog header with title and close button */}
-          <DialogTitle className="text-2xl">Swap Source</DialogTitle>
+          <DialogTitle className="font-display text-xl font-bold uppercase tracking-[0.15em] text-glow">Swap Source</DialogTitle>
           <DialogClose>
             <X className="w-7 h-7 p-1 bg-primary rounded-full font-bold text-black hover:bg-primary-dark transition-colors duration-300" />
           </DialogClose>
         </DialogHeader>
-        <Separator className="bg-separator" />
-        <Label className="text-lg">Select Blockchain</Label>
+        <Separator className="bg-gradient-to-r from-transparent via-primary/40 to-transparent" />
+        <Label className="text-sm font-medium uppercase tracking-wider text-white/50">Select Blockchain</Label>
         {/* Display blockchain options */}
         <Blockchains selectedBlockchain={selectedBlockchain} setSelectedBlockchain={setSelectedBlockchain} />
         {/* Show token selection if a blockchain is selected */}
         {selectedBlockchain &&
           <>
-            <Label className="text-lg">Select Token</Label>
+            <Label className="text-sm font-medium uppercase tracking-wider text-white/50">Select Token</Label>
             {/* Search input for filtering tokens */}
             <Search value={search} onChange={(e) => setSearch(e.target.value)} />
             <div id="scrollableDiv" className="max-h-72 overflow-y-auto">
@@ -134,8 +134,8 @@ const TokenModal: React.FC<PropsWithChildren<TokenModalProps>> = ({ children, se
                   const tokenAmountInUSD = getTokenAmount(token, true);
                   return (
                     <DialogClose
-                      className={cn("p-2 border rounded-3xl w-full cursor-pointer bg-transparent hover:bg-white/5 transition-colors duration-300",
-                        isSelected ? "border-primary" : "border-separator"
+                      className={cn("p-2 border rounded-2xl w-full cursor-pointer bg-transparent hover:bg-primary/5 hover:border-primary/50 transition-all duration-300",
+                        isSelected ? "border-primary shadow-neon-sm bg-primary/10" : "border-white/10"
                       )}
                       onClick={() => setToken(token)} // Update selected token
                       key={index}

--- a/app/_components/dexifier/WalletConnectModal.tsx
+++ b/app/_components/dexifier/WalletConnectModal.tsx
@@ -8,15 +8,6 @@ import { useStatefulConnect, useWalletList, WalletInfoWithExtra } from "@rango-d
 import { WalletState } from "@rango-dev/ui";
 import type { Namespace } from "@hub3js/namespaces";
 
-// Background colors for different wallet states
-const BgColorSet: Record<WalletState, string> = {
-  [WalletState.NOT_INSTALLED]: "#97979763",
-  [WalletState.DISCONNECTED]: "#639cff6e",
-  [WalletState.CONNECTING]: "#5ce3ff63",
-  [WalletState.CONNECTED]: "#639cff6e",
-  [WalletState.PARTIALLY_CONNECTED]: "#639cff6e",
-};
-
 // Text colors for different wallet states
 const TextColorSet: Record<WalletState, string> = {
   [WalletState.NOT_INSTALLED]: "#a6e6ffad",
@@ -85,27 +76,26 @@ const WalletConnectModal: React.FC<PropsWithChildren<WalletConnectModalProps>> =
     <Dialog>
       {/* Trigger dialog via children */}
       <DialogTrigger asChild>{props.children}</DialogTrigger>
-      <DialogContent className="sm:max-w-md bg-transparent max-h-[90vh] max-w-[90vw] p-4 md:p-6 bg-gradient-to-b from-black to-[#042214] border border-separator !rounded-3xl">
+      <DialogContent className="sm:max-w-md bg-transparent max-h-[90vh] max-w-[90vw] p-4 md:p-6 bg-[#041008]/95 backdrop-blur-2xl border border-primary/25 shadow-neon-lg !rounded-3xl">
         {/* Dialog header with title and close button */}
         <DialogHeader className="flex flex-row justify-between">
-          <DialogTitle className="text-2xl">Connect <span className="text-primary">{props.chain}</span> Wallets</DialogTitle>
+          <DialogTitle className="font-display text-xl font-bold uppercase tracking-[0.15em]">Connect <span className="text-primary">{props.chain}</span> Wallets</DialogTitle>
           <DialogClose>
             <X className="w-7 h-7 p-1 bg-primary rounded-full font-bold text-black hover:bg-primary-dark transition-colors duration-300" />
           </DialogClose>
         </DialogHeader>
-        <Separator className="bg-separator" /> {/* Separator between header and content */}
+        <Separator className="bg-gradient-to-r from-transparent via-primary/40 to-transparent" /> {/* Separator between header and content */}
         {/* Search component for filtering wallets */}
         <Search value={search} onChange={(e) => setSearch(e.target.value)} />
         <div className="max-h-[60vh] flex flex-wrap justify-center overflow-auto gap-2 pr-1">
           {/* Render filtered wallets */}
           {filteredWalletList?.map((wallet, index) => (
-            <button key={index} className="flex flex-col min-w-[125px] items-center justify-center p-2 rounded-lg disabled:cursor-not-allowed hover:opacity-80"
-              style={{ backgroundColor: BgColorSet[wallet.state] }} // Set background color based on wallet state
+            <button key={index} className="flex flex-col min-w-[125px] items-center justify-center gap-1 p-3 rounded-2xl border border-white/10 bg-white/5 disabled:cursor-not-allowed hover:bg-primary/10 hover:border-primary/50 hover:shadow-neon-sm hover:-translate-y-0.5 transition-all duration-300"
               onClick={() => handleWallet(wallet)} // Handle wallet click to connect, disconnect, or open installation link
             >
               <Image src={wallet.image} alt={wallet.type} width={45} height={45} /> {/* Wallet image */}
-              <span className="text-sm">{wallet.title}</span> {/* Wallet title */}
-              <span className="text-xs color-grey-500" style={{ color: TextColorSet[wallet.state] }}>
+              <span className="text-sm font-medium">{wallet.title}</span> {/* Wallet title */}
+              <span className="text-xs" style={{ color: TextColorSet[wallet.state] }}>
                 {/* Wallet state text with color based on wallet state */}
                 {wallet.state}
               </span>

--- a/app/_components/navbar/WalletDetails.tsx
+++ b/app/_components/navbar/WalletDetails.tsx
@@ -158,8 +158,8 @@ const WalletDetails: React.FC<WalletDetailsProps> = ({ children }) => {
       <SheetTrigger asChild>
         {children}
       </SheetTrigger>
-      <SheetContent className="bg-gradient-to-b to-[#002f19] from-[#01150c] p-4 min-w-[450px] flex flex-col">
-        <SheetHeader className="border-b border-separator">
+      <SheetContent className="bg-[#041008]/95 backdrop-blur-2xl border-l border-primary/25 p-4 min-w-[450px] flex flex-col">
+        <SheetHeader className="border-b border-white/10">
           <SheetTitle className="w-full flex justify-center relative p-2">
             <span className="text-xl text-primary">
               {balancePending ? "…" : `${formatUsd(getWalletBalanceInUSD(filteredWallets))}$`}

--- a/app/globals.css
+++ b/app/globals.css
@@ -36,65 +36,132 @@ body {
 }
 
 /* ---- Animated aurora background ---- */
+/* Orbs: compact bright cores so they read as glowing blobs, not haze.
+   Two nested gradients: hot center + soft halo. */
 .aurora-orb {
   position: absolute;
   border-radius: 9999px;
-  filter: blur(110px);
   mix-blend-mode: screen;
-  will-change: transform;
+  will-change: transform, opacity;
 }
 .aurora-orb-1 {
-  width: 55vw;
-  height: 55vw;
-  left: -15vw;
-  top: -22vw;
-  background: radial-gradient(circle at 40% 40%, rgba(19, 241, 135, 0.5), transparent 62%);
-  animation: aurora-drift-1 26s ease-in-out infinite alternate;
+  width: 38vw;
+  height: 38vw;
+  left: -8vw;
+  top: -12vw;
+  background: radial-gradient(
+    circle at 50% 50%,
+    rgba(19, 241, 135, 0.55) 0%,
+    rgba(19, 241, 135, 0.22) 32%,
+    transparent 68%
+  );
+  filter: blur(60px);
+  animation:
+    aurora-drift-1 14s ease-in-out infinite alternate,
+    aurora-breathe 7s ease-in-out infinite;
 }
 .aurora-orb-2 {
-  width: 44vw;
-  height: 44vw;
-  right: -12vw;
-  top: -10vw;
-  background: radial-gradient(circle at 60% 40%, rgba(0, 224, 255, 0.3), transparent 60%);
-  animation: aurora-drift-2 32s ease-in-out infinite alternate;
+  width: 30vw;
+  height: 30vw;
+  right: -6vw;
+  top: -6vw;
+  background: radial-gradient(
+    circle at 50% 50%,
+    rgba(0, 224, 255, 0.42) 0%,
+    rgba(0, 224, 255, 0.16) 34%,
+    transparent 68%
+  );
+  filter: blur(55px);
+  animation:
+    aurora-drift-2 18s ease-in-out infinite alternate,
+    aurora-breathe 9s ease-in-out infinite 1.5s;
 }
 .aurora-orb-3 {
-  width: 62vw;
-  height: 62vw;
-  left: 18vw;
-  bottom: -38vw;
-  background: radial-gradient(circle at 50% 50%, rgba(15, 189, 107, 0.38), transparent 64%);
-  animation: aurora-drift-3 38s ease-in-out infinite alternate;
+  width: 42vw;
+  height: 42vw;
+  left: 28vw;
+  bottom: -24vw;
+  background: radial-gradient(
+    circle at 50% 50%,
+    rgba(15, 189, 107, 0.5) 0%,
+    rgba(15, 189, 107, 0.2) 34%,
+    transparent 70%
+  );
+  filter: blur(65px);
+  animation:
+    aurora-drift-3 16s ease-in-out infinite alternate,
+    aurora-breathe 8s ease-in-out infinite 3s;
 }
 @keyframes aurora-drift-1 {
+  from {
+    transform: translate(0, 0) scale(1);
+  }
   to {
-    transform: translate(9vw, 7vh) scale(1.14);
+    transform: translate(10vw, 8vh) scale(1.18);
   }
 }
 @keyframes aurora-drift-2 {
+  from {
+    transform: translate(0, 0) scale(1.1);
+  }
   to {
-    transform: translate(-8vw, 9vh) scale(1.1);
+    transform: translate(-9vw, 10vh) scale(0.94);
   }
 }
 @keyframes aurora-drift-3 {
+  from {
+    transform: translate(0, 0) scale(1);
+  }
   to {
-    transform: translate(-6vw, -7vh) scale(1.16);
+    transform: translate(-8vw, -8vh) scale(1.2);
+  }
+}
+@keyframes aurora-breathe {
+  0%,
+  100% {
+    opacity: 0.85;
+  }
+  50% {
+    opacity: 1;
   }
 }
 
-/* Perspective grid fading in from the horizon */
+/* Perspective grid rising from the horizon, slowly rolling forward */
 .dex-grid {
   position: absolute;
   inset: 0;
   background-image:
-    linear-gradient(rgba(19, 241, 135, 0.08) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(19, 241, 135, 0.08) 1px, transparent 1px);
+    linear-gradient(rgba(19, 241, 135, 0.09) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(19, 241, 135, 0.09) 1px, transparent 1px);
   background-size: 60px 60px;
   mask-image: radial-gradient(ellipse 90% 55% at 50% 115%, black 25%, transparent 72%);
   -webkit-mask-image: radial-gradient(ellipse 90% 55% at 50% 115%, black 25%, transparent 72%);
   transform: perspective(650px) rotateX(38deg) scale(2.4);
   transform-origin: bottom;
+  animation: grid-roll 3.2s linear infinite;
+}
+@keyframes grid-roll {
+  to {
+    background-position: 0 60px, 0 0;
+  }
+}
+
+/* Entrance rise for the main cards */
+@keyframes dex-rise {
+  from {
+    opacity: 0;
+    transform: translateY(26px) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+.animate-rise {
+  animation: dex-rise 0.7s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+.route-row-enter {
+  animation: dex-rise 0.45s cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
 /* Film grain so the glows don't look like flat vector blobs */


### PR DESCRIPTION
**Background fix** — orbs rebuilt as compact hot-core blobs (38–42vw, 55–65px blur, 0.4–0.55 alpha cores) with visible 14–18s drift and 7–9s opacity breathing. They read as orbs now. Perspective grid rolls forward continuously.

**Animation pass** — cards rise in on load, route rows stagger 70ms apart, CTA breathes pulse-glow while enabled, flip button idles with pulse, chain cells and wallet buttons lift + glow on hover.

**Stage 3 — modals on the neon system** — all dialogs (token selector, blockchain list, wallet connect, confirm, settings) get deep glass + primary border + neon-lg shadow; Space Grotesk uppercase titles; restyled search; token rows with hover neon + selected glow; wallet buttons as glass chips with hover lift; WalletDetails sheet, AddressCard, DetailRango brought into the same card language.

tsc clean, 39/39 tests, 0 lint errors.