### PR TITLE
Slow glow flicker + transparent glass surfaces

### DIFF
--- a/app/_components/dexifier/DexifierCard.tsx
+++ b/app/_components/dexifier/DexifierCard.tsx
@@ -80,7 +80,7 @@ const DexifierCard: React.FC = () => {
   return (
     <Card
       className={cn(
-        "w-full text-white rounded-[28px] border border-primary/25 bg-[#041008]/85 backdrop-blur-2xl neon-frame animate-rise",
+        "w-full text-white rounded-[28px] border border-primary/25 bg-[#041008]/35 backdrop-blur-2xl neon-frame animate-rise",
         isMobile ? "p-0 border-none bg-transparent shadow-none backdrop-blur-none before:hidden" : "max-w-[560px] p-8"
       )}
     >
@@ -158,7 +158,7 @@ const DexifierCard: React.FC = () => {
 
           {/* Reverse Swap Button */}
           <Button
-            className="self-center mt-7 mb-1 h-[54px] w-[54px] rounded-full border-none bg-primary p-1 text-black shadow-neon animate-pulse-glow transition-all duration-500 hover:rotate-180 hover:shadow-neon-lg hover:brightness-110"
+            className="self-center mt-7 mb-1 h-[54px] w-[54px] rounded-full border-none bg-primary p-1 text-black shadow-neon animate-pulse-glow-slow transition-all duration-500 hover:rotate-180 hover:shadow-neon-lg hover:brightness-110"
             onClick={reverseTokenPair}
           >
             <ArrowDownUp size={24} strokeWidth={2.5} />

--- a/app/_components/dexifier/RouteCard.tsx
+++ b/app/_components/dexifier/RouteCard.tsx
@@ -409,7 +409,7 @@ const RouteCard = () => {
   return (
     <Card
       className={cn(
-        "h-full flex flex-col w-full rounded-[28px] border border-primary/25 bg-[#041008]/85 backdrop-blur-2xl neon-frame animate-rise text-white",
+        "h-full flex flex-col w-full rounded-[28px] border border-primary/25 bg-[#041008]/35 backdrop-blur-2xl neon-frame animate-rise text-white",
         isMobile ? "p-5 border-none bg-transparent shadow-none backdrop-blur-none before:hidden" : "max-w-[650px] p-6"
       )}
     >

--- a/app/_components/navbar/MainNavbar.tsx
+++ b/app/_components/navbar/MainNavbar.tsx
@@ -85,7 +85,7 @@ const MainNavbar = () => {
       className={cn(scrolled ? '' : 'bg-transparent', 'w-screen transition fixed top-0 z-50 duration-300')}
     >
       <div className={`max-w-[86rem] mx-auto px-2 sm:px-6 lg:px-8 pt-5 pb-4`}>
-        <div className="relative flex items-center justify-center md:justify-between rounded-full border border-white/10 bg-black/40 backdrop-blur-xl px-6 py-3">
+        <div className="relative flex items-center justify-center md:justify-between rounded-full border border-white/10 bg-black/25 backdrop-blur-xl px-6 py-3">
           {/* Logo */}
           <div className="absolute inset-0 flex items-center md:hidden">
             <button
@@ -152,7 +152,7 @@ const MainNavbar = () => {
             ))}
             {(!connectedWallets.length ?
               <WalletConnectModal>
-                <button className="flex text-[1.075rem] bg-primary rounded-full py-2 px-4 gap-2 items-center justify-center shadow-neon transition hover:shadow-neon-lg hover:brightness-110">
+                <button className="flex text-[1.075rem] bg-primary rounded-full py-2 px-4 gap-2 items-center justify-center shadow-neon animate-pulse-glow-slow transition hover:shadow-neon-lg hover:brightness-110">
                   <BiSolidWallet className="size-6 text-black" />
                   <span className="text-black font-semibold">Connect Wallet</span>
                 </button>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -57,6 +57,7 @@ const config = {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
         "pulse-glow": "pulse-glow 3s ease-in-out infinite",
+        "pulse-glow-slow": "pulse-glow 8s ease-in-out infinite",
       },
       screens: {
         xs: "450px",


### PR DESCRIPTION
Flip button flicker slowed 3s to 8s and the same slow glow added to Connect Wallet. Swap card, routes card, and navbar are now transparent glass over the animated scene.