### PR TITLE
Deepen glass transparency so it reads over the dark scene

### DIFF
--- a/app/_components/dexifier/DexifierCard.tsx
+++ b/app/_components/dexifier/DexifierCard.tsx
@@ -80,7 +80,7 @@ const DexifierCard: React.FC = () => {
   return (
     <Card
       className={cn(
-        "w-full text-white rounded-[28px] border border-primary/25 bg-[#041008]/35 backdrop-blur-2xl neon-frame animate-rise",
+        "w-full text-white rounded-[28px] border border-primary/25 bg-[#041008]/20 backdrop-blur-2xl neon-frame animate-rise",
         isMobile ? "p-0 border-none bg-transparent shadow-none backdrop-blur-none before:hidden" : "max-w-[560px] p-8"
       )}
     >

--- a/app/_components/dexifier/RouteCard.tsx
+++ b/app/_components/dexifier/RouteCard.tsx
@@ -409,7 +409,7 @@ const RouteCard = () => {
   return (
     <Card
       className={cn(
-        "h-full flex flex-col w-full rounded-[28px] border border-primary/25 bg-[#041008]/35 backdrop-blur-2xl neon-frame animate-rise text-white",
+        "h-full flex flex-col w-full rounded-[28px] border border-primary/25 bg-[#041008]/20 backdrop-blur-2xl neon-frame animate-rise text-white",
         isMobile ? "p-5 border-none bg-transparent shadow-none backdrop-blur-none before:hidden" : "max-w-[650px] p-6"
       )}
     >

--- a/app/_components/navbar/MainNavbar.tsx
+++ b/app/_components/navbar/MainNavbar.tsx
@@ -85,7 +85,7 @@ const MainNavbar = () => {
       className={cn(scrolled ? '' : 'bg-transparent', 'w-screen transition fixed top-0 z-50 duration-300')}
     >
       <div className={`max-w-[86rem] mx-auto px-2 sm:px-6 lg:px-8 pt-5 pb-4`}>
-        <div className="relative flex items-center justify-center md:justify-between rounded-full border border-white/10 bg-black/25 backdrop-blur-xl px-6 py-3">
+        <div className="relative flex items-center justify-center md:justify-between rounded-full border border-white/10 bg-black/10 backdrop-blur-xl px-6 py-3">
           {/* Logo */}
           <div className="absolute inset-0 flex items-center md:hidden">
             <button


### PR DESCRIPTION
Card tint to 20%, navbar to 10% - over the near-black center the previous values were visually identical to the old ones.