### PR TITLE
Fix flip-button strobe; true iOS-style frosted glass

### DIFF
--- a/app/_components/dexifier/DexifierCard.tsx
+++ b/app/_components/dexifier/DexifierCard.tsx
@@ -80,7 +80,7 @@ const DexifierCard: React.FC = () => {
   return (
     <Card
       className={cn(
-        "w-full text-white rounded-[28px] border border-primary/25 bg-[#041008]/20 backdrop-blur-2xl neon-frame animate-rise",
+        "w-full text-white rounded-[28px] border border-primary/25 bg-white/[0.07] backdrop-blur-2xl backdrop-saturate-150 neon-frame animate-rise",
         isMobile ? "p-0 border-none bg-transparent shadow-none backdrop-blur-none before:hidden" : "max-w-[560px] p-8"
       )}
     >
@@ -158,7 +158,7 @@ const DexifierCard: React.FC = () => {
 
           {/* Reverse Swap Button */}
           <Button
-            className="self-center mt-7 mb-1 h-[54px] w-[54px] rounded-full border-none bg-primary p-1 text-black shadow-neon animate-pulse-glow-slow transition-all duration-500 hover:rotate-180 hover:shadow-neon-lg hover:brightness-110"
+            className="self-center mt-7 mb-1 h-[54px] w-[54px] rounded-full border-none bg-primary p-1 text-black shadow-neon animate-pulse-glow-slow transition-all [transition-duration:500ms] hover:rotate-180 hover:shadow-neon-lg hover:brightness-110"
             onClick={reverseTokenPair}
           >
             <ArrowDownUp size={24} strokeWidth={2.5} />

--- a/app/_components/dexifier/RouteCard.tsx
+++ b/app/_components/dexifier/RouteCard.tsx
@@ -409,7 +409,7 @@ const RouteCard = () => {
   return (
     <Card
       className={cn(
-        "h-full flex flex-col w-full rounded-[28px] border border-primary/25 bg-[#041008]/20 backdrop-blur-2xl neon-frame animate-rise text-white",
+        "h-full flex flex-col w-full rounded-[28px] border border-primary/25 bg-white/[0.07] backdrop-blur-2xl backdrop-saturate-150 neon-frame animate-rise text-white",
         isMobile ? "p-5 border-none bg-transparent shadow-none backdrop-blur-none before:hidden" : "max-w-[650px] p-6"
       )}
     >

--- a/app/_components/navbar/MainNavbar.tsx
+++ b/app/_components/navbar/MainNavbar.tsx
@@ -85,7 +85,7 @@ const MainNavbar = () => {
       className={cn(scrolled ? '' : 'bg-transparent', 'w-screen transition fixed top-0 z-50 duration-300')}
     >
       <div className={`max-w-[86rem] mx-auto px-2 sm:px-6 lg:px-8 pt-5 pb-4`}>
-        <div className="relative flex items-center justify-center md:justify-between rounded-full border border-white/10 bg-black/10 backdrop-blur-xl px-6 py-3">
+        <div className="relative flex items-center justify-center md:justify-between rounded-full border border-white/10 bg-white/[0.06] backdrop-blur-xl backdrop-saturate-150 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.08)] px-6 py-3">
           {/* Logo */}
           <div className="absolute inset-0 flex items-center md:hidden">
             <button

--- a/app/globals.css
+++ b/app/globals.css
@@ -133,7 +133,8 @@ body {
   position: relative;
   box-shadow:
     0 0 90px rgba(19, 241, 135, 0.13),
-    0 24px 70px rgba(0, 0, 0, 0.6);
+    0 24px 70px rgba(0, 0, 0, 0.6),
+    inset 0 1px 0 rgba(255, 255, 255, 0.14);
 }
 .neon-frame::before {
   content: "";

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -15,7 +15,7 @@ const buttonVariants = cva(
           "bg-slate-900 text-slate-50 hover:bg-slate-900/90 dark:bg-slate-50 dark:text-slate-900 dark:hover:bg-slate-50/90",
         primary:
           "w-full bg-primary hover:bg-primary-dark transition duration-300 text-black rounded-md font-semibold text-base xl:text-xl",
-        neon: "w-full bg-gradient-to-r from-primary to-accent text-black font-bold rounded-2xl shadow-neon hover:shadow-neon-lg hover:brightness-110 active:scale-[0.99] transition-all duration-300 disabled:bg-none disabled:bg-white/5 disabled:text-white/40 disabled:border disabled:border-white/10 disabled:shadow-none disabled:opacity-100",
+        neon: "w-full bg-gradient-to-r from-primary to-accent text-black font-bold rounded-2xl shadow-neon hover:shadow-neon-lg hover:brightness-110 active:scale-[0.99] transition-all [transition-duration:300ms] disabled:bg-none disabled:bg-white/5 disabled:text-white/40 disabled:border disabled:border-white/10 disabled:shadow-none disabled:opacity-100",
         secondary: `bg-white text-black font-bold text-base ${inter.className}`,
         destructive:
           "bg-red-500 text-slate-50 hover:bg-red-500/90 dark:bg-red-900 dark:text-slate-50 dark:hover:bg-red-900/90",


### PR DESCRIPTION
Root cause: tailwindcss-animate duration-* rules set animation-duration, compressing the flip glow to 0.5s. Now uses [transition-duration]. Glass: white tint + blur + saturate + specular top edge.