### PR TITLE
Stage 5: mobile bottom-sheets, sticky CTA, touch targets

### DIFF
--- a/app/_components/common/responsive-modal.tsx
+++ b/app/_components/common/responsive-modal.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+// Responsive modal primitives: a centered Dialog on desktop, a bottom sheet
+// (rounded top, drag handle, slide-up) on mobile. One API for both.
+import { useDexifier } from "@/app/providers/DexifierProvider";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import { cn } from "@/lib/utils";
+import { ComponentProps, ElementType, ReactNode } from "react";
+
+type ModalParts = {
+  Root: ElementType;
+  Trigger: ElementType;
+  Close: ElementType;
+  Header: ElementType;
+  Title: ElementType;
+  isMobile: boolean;
+};
+
+export const useResponsiveModal = (): ModalParts => {
+  const { isMobile } = useDexifier();
+  return {
+    Root: isMobile ? Sheet : Dialog,
+    Trigger: isMobile ? SheetTrigger : DialogTrigger,
+    Close: isMobile ? SheetClose : DialogClose,
+    Header: isMobile ? SheetHeader : DialogHeader,
+    Title: isMobile ? SheetTitle : DialogTitle,
+    isMobile,
+  };
+};
+
+type ResponsiveContentProps = ComponentProps<typeof DialogContent> & {
+  children: ReactNode;
+};
+
+export const ResponsiveContent = ({
+  className,
+  children,
+  ...props
+}: ResponsiveContentProps) => {
+  const { isMobile } = useDexifier();
+  if (isMobile) {
+    return (
+      <SheetContent
+        side="bottom"
+        className={cn(
+          "flex flex-col max-h-[88vh] rounded-t-3xl border-t border-primary/25 bg-[#041008]/95 backdrop-blur-2xl p-4 pb-8",
+          className
+        )}
+        {...props}
+      >
+        {/* drag handle */}
+        <div className="mx-auto mb-2 h-1 w-10 shrink-0 rounded-full bg-white/20" />
+        {children}
+      </SheetContent>
+    );
+  }
+  return (
+    <DialogContent className={className} {...props}>
+      {children}
+    </DialogContent>
+  );
+};

--- a/app/_components/dexifier/ConfirmModal.tsx
+++ b/app/_components/dexifier/ConfirmModal.tsx
@@ -12,15 +12,8 @@ import CustomLoader from "../common/loader";
 import { confirmRangoRoute } from "@/lib/api-client";
 import { toastError } from "@/lib/utils";
 import { Separator } from "@/components/ui/separator";
-import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
+import { ResponsiveContent, useResponsiveModal } from "../common/responsive-modal";
+import { DialogDescription } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import {
   ConnectedWallet,
@@ -75,6 +68,7 @@ const ConfirmModal: React.FC<PropsWithChildren> = (props) => {
     setState,
     isMobile,
   } = useDexifier();
+  const { Root, Trigger, Close, Header, Title } = useResponsiveModal();
   const [isInitializingSwap, initializeSwap] = useTransition();
 
   // State hooks for managing the modal, wallets, and withdrawal address input
@@ -252,21 +246,21 @@ const ConfirmModal: React.FC<PropsWithChildren> = (props) => {
   };
 
   return (
-    <Dialog
+    <Root
       open={open}
-      onOpenChange={(open) => {
+      onOpenChange={(open: boolean) => {
         // setConfirmData(undefined);  // Clear confirmation data when modal is closed
         setOpen(open);
       }}
     >
-      <DialogTrigger asChild>{props.children}</DialogTrigger>
-      <DialogContent className="w-[30rem] bg-transparent max-h-[90vh] max-w-[90vw] p-6 bg-[#041008]/95 backdrop-blur-2xl border border-primary/25 shadow-neon-lg !rounded-3xl">
-        <DialogHeader>
+      <Trigger asChild>{props.children}</Trigger>
+      <ResponsiveContent className="md:w-[30rem] md:max-h-[90vh] md:max-w-[90vw] p-6 md:bg-[#041008]/95 md:backdrop-blur-2xl md:border md:border-primary/25 md:shadow-neon-lg md:!rounded-3xl">
+        <Header>
           <div className="flex flex-row justify-between p-2">
-            <DialogTitle className="font-display text-xl font-bold uppercase tracking-[0.15em] text-glow">Confirm</DialogTitle>
-            <DialogClose>
+            <Title className="font-display text-xl font-bold uppercase tracking-[0.15em] text-glow">Confirm</Title>
+            <Close>
               <X className="w-7 h-7 p-1 bg-primary rounded-full font-bold text-black hover:bg-primary-dark transition-colors duration-300" />
-            </DialogClose>
+            </Close>
           </div>
           <Separator className="bg-gradient-to-r from-transparent via-primary/40 to-transparent" />
           <DialogDescription className="flex items-center justify-around">
@@ -291,7 +285,7 @@ const ConfirmModal: React.FC<PropsWithChildren> = (props) => {
               <Image src={"/assets/icons/reset-icon.png"} width={20} height={20} alt="refresh" />
             </button> */}
           </DialogDescription>
-        </DialogHeader>
+        </Header>
         <div className="h-[40vh] overflow-y-auto pe-1">
           <div className="space-y-4">
             {Array.from(
@@ -408,8 +402,8 @@ const ConfirmModal: React.FC<PropsWithChildren> = (props) => {
             "Confirm"
           )}
         </Button>
-      </DialogContent>
-    </Dialog>
+      </ResponsiveContent>
+    </Root>
   );
 };
 

--- a/app/_components/dexifier/RouteCard.tsx
+++ b/app/_components/dexifier/RouteCard.tsx
@@ -339,7 +339,7 @@ const RouteCard = () => {
                 value={filter}
                 id={filter}
                 key={filter}
-                className="rounded-full border border-white/15 px-3 py-1 text-nowrap text-xs text-white/70 transition duration-300 hover:border-primary/50 hover:text-white data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:font-semibold data-[state=checked]:text-black data-[state=checked]:shadow-neon-sm"
+                className="rounded-full border border-white/15 px-3 py-1 max-sm:min-h-11 max-sm:px-5 max-sm:text-sm text-nowrap text-xs text-white/70 transition duration-300 hover:border-primary/50 hover:text-white data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:font-semibold data-[state=checked]:text-black data-[state=checked]:shadow-neon-sm"
               >
                 {filter}
               </RadioGroupPrimitive.Item>

--- a/app/_components/dexifier/TokenModal/index.tsx
+++ b/app/_components/dexifier/TokenModal/index.tsx
@@ -5,13 +5,9 @@ import React, { Dispatch, PropsWithChildren, SetStateAction, useCallback, useEff
 import { Check, X } from "lucide-react";
 import { isEqual } from "lodash";
 import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
+  ResponsiveContent,
+  useResponsiveModal,
+} from "../../common/responsive-modal";
 import TooltipTemplate from "../../common/tooltip-template";
 import Search from "../../common/search";
 import InfiniteScroll from 'react-infinite-scroll-component';
@@ -46,6 +42,7 @@ const TokenModal: React.FC<PropsWithChildren<TokenModalProps>> = ({ children, se
   // const { tokens } = meta; // Extract tokens from the metadata
   const { details: connectedWallets } = wallets;
   const { coins } = useDexifier();
+  const { Root, Trigger, Close, Header, Title } = useResponsiveModal();
 
   // Effect to filter tokens based on the selected blockchain
   useEffect(() => {
@@ -96,17 +93,17 @@ const TokenModal: React.FC<PropsWithChildren<TokenModalProps>> = ({ children, se
   }
 
   return (
-    <Dialog>
+    <Root>
       {/* Trigger to open the dialog */}
-      <DialogTrigger asChild>{children}</DialogTrigger>
-      <DialogContent className="flex flex-col sm:max-w-md max-h-[90vh] max-w-[90vw] p-4 md:p-6 bg-[#041008]/95 backdrop-blur-2xl border border-primary/25 shadow-neon-lg !rounded-3xl">
-        <DialogHeader className="flex flex-row justify-between">
+      <Trigger asChild>{children}</Trigger>
+      <ResponsiveContent className="flex flex-col sm:max-w-md md:max-h-[90vh] md:max-w-[90vw] p-4 md:p-6 md:bg-[#041008]/95 md:backdrop-blur-2xl md:border md:border-primary/25 md:shadow-neon-lg md:!rounded-3xl">
+        <Header className="flex flex-row justify-between">
           {/* Dialog header with title and close button */}
-          <DialogTitle className="font-display text-xl font-bold uppercase tracking-[0.15em] text-glow">Swap Source</DialogTitle>
-          <DialogClose>
+          <Title className="font-display text-xl font-bold uppercase tracking-[0.15em] text-glow">Swap Source</Title>
+          <Close>
             <X className="w-7 h-7 p-1 bg-primary rounded-full font-bold text-black hover:bg-primary-dark transition-colors duration-300" />
-          </DialogClose>
-        </DialogHeader>
+          </Close>
+        </Header>
         <Separator className="bg-gradient-to-r from-transparent via-primary/40 to-transparent" />
         <Label className="text-sm font-medium uppercase tracking-wider text-white/50">Select Blockchain</Label>
         {/* Display blockchain options */}
@@ -133,7 +130,7 @@ const TokenModal: React.FC<PropsWithChildren<TokenModalProps>> = ({ children, se
                   const tokenAmount = getTokenAmount(token);
                   const tokenAmountInUSD = getTokenAmount(token, true);
                   return (
-                    <DialogClose
+                    <Close
                       className={cn("p-2 border rounded-2xl w-full cursor-pointer bg-transparent hover:bg-primary/5 hover:border-primary/50 transition-all duration-300",
                         isSelected ? "border-primary shadow-neon-sm bg-primary/10" : "border-white/10"
                       )}
@@ -186,15 +183,15 @@ const TokenModal: React.FC<PropsWithChildren<TokenModalProps>> = ({ children, se
                           </div>
                         </div>
                       </div>
-                    </DialogClose>
+                    </Close>
                   )
                 })}
               </InfiniteScroll>
             </div>
           </>
         }
-      </DialogContent>
-    </Dialog>
+      </ResponsiveContent>
+    </Root>
   );
 };
 

--- a/app/_components/dexifier/WalletConnectModal.tsx
+++ b/app/_components/dexifier/WalletConnectModal.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
 import Search from "../common/search";
 import { PropsWithChildren, useMemo, useState } from "react";
-import { Dialog, DialogClose, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { ResponsiveContent, useResponsiveModal } from "../common/responsive-modal";
 import { X } from "lucide-react";
 import { Separator } from "@/components/ui/separator";
 import { useStatefulConnect, useWalletList, WalletInfoWithExtra } from "@rango-dev/widget-embedded";
@@ -23,6 +23,7 @@ interface WalletConnectModalProps {
 }
 
 const WalletConnectModal: React.FC<PropsWithChildren<WalletConnectModalProps>> = (props) => {
+  const { Root, Trigger, Close, Header, Title } = useResponsiveModal();
   const [search, setSearch] = useState<string>(""); // State for search input
   const { list } = useWalletList({ chain: props.chain }); // Fetch wallet list filtered by chain (if provided)
   // Hub-based wallets (MetaMask, Phantom, …) require explicit namespaces when
@@ -73,17 +74,17 @@ const WalletConnectModal: React.FC<PropsWithChildren<WalletConnectModalProps>> =
   }
 
   return (
-    <Dialog>
+    <Root>
       {/* Trigger dialog via children */}
-      <DialogTrigger asChild>{props.children}</DialogTrigger>
-      <DialogContent className="sm:max-w-md bg-transparent max-h-[90vh] max-w-[90vw] p-4 md:p-6 bg-[#041008]/95 backdrop-blur-2xl border border-primary/25 shadow-neon-lg !rounded-3xl">
+      <Trigger asChild>{props.children}</Trigger>
+      <ResponsiveContent className="sm:max-w-md md:max-h-[90vh] md:max-w-[90vw] p-4 md:p-6 md:bg-[#041008]/95 md:backdrop-blur-2xl md:border md:border-primary/25 md:shadow-neon-lg md:!rounded-3xl">
         {/* Dialog header with title and close button */}
-        <DialogHeader className="flex flex-row justify-between">
-          <DialogTitle className="font-display text-xl font-bold uppercase tracking-[0.15em]">Connect <span className="text-primary">{props.chain}</span> Wallets</DialogTitle>
-          <DialogClose>
+        <Header className="flex flex-row justify-between">
+          <Title className="font-display text-xl font-bold uppercase tracking-[0.15em]">Connect <span className="text-primary">{props.chain}</span> Wallets</Title>
+          <Close>
             <X className="w-7 h-7 p-1 bg-primary rounded-full font-bold text-black hover:bg-primary-dark transition-colors duration-300" />
-          </DialogClose>
-        </DialogHeader>
+          </Close>
+        </Header>
         <Separator className="bg-gradient-to-r from-transparent via-primary/40 to-transparent" /> {/* Separator between header and content */}
         {/* Search component for filtering wallets */}
         <Search value={search} onChange={(e) => setSearch(e.target.value)} />
@@ -102,8 +103,8 @@ const WalletConnectModal: React.FC<PropsWithChildren<WalletConnectModalProps>> =
             </button>
           ))}
         </div>
-      </DialogContent>
-    </Dialog>
+      </ResponsiveContent>
+    </Root>
   )
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -85,9 +85,9 @@ export default function SwapPage() {
         )}
       </section>
       {isMobile && (
-        <div className="flex-1 py-12">
+        <div className="sticky bottom-0 z-40 -mx-8 mt-auto px-8 pb-6 pt-10 bg-gradient-to-t from-[#020805] via-[#020805]/90 to-transparent">
           <Button
-            className="w-full h-12"
+            className="btn-sheen w-full h-14 rounded-2xl text-lg font-extrabold uppercase tracking-widest"
             variant={state === DEXIFIER_STATE.PENDING ? 'outline' : 'neon'}
             disabled={!selectedRoute || state === DEXIFIER_STATE.PENDING}
             onClick={() => {


### PR DESCRIPTION
- New responsive-modal primitive: Dialog on desktop, bottom Sheet with drag handle on mobile
- TokenModal, ConfirmModal, WalletConnectModal converted
- Sticky bottom CTA on mobile with gradient backdrop, h-14 uppercase sheen button
- Route filter chips bumped to 44px touch target on mobile