### PR TITLE
Fix: mobile routes overflow + address pill text spill

### DIFF
--- a/app/_components/dexifier/AddressCard.tsx
+++ b/app/_components/dexifier/AddressCard.tsx
@@ -300,7 +300,7 @@ const renderChainflipStatus = (state: string) => {
       </CardHeader>
       <Separator className="bg-gradient-to-r from-transparent via-primary/40 to-transparent md:block hidden" />
       <CardContent className="flex flex-col md:px-6 md:pb-0 p-4 overflow-y-auto overflow-x-hidden flex-1">
-        <div className="flex w-full md:justify-center items-center gap-3 md:my-4 mb-6 md:text-lg text-sm font-bold tnum bg-white/5 border border-white/10 rounded-2xl px-3 py-2">
+        <div className="flex w-full md:justify-center items-center justify-center flex-wrap gap-x-3 gap-y-1.5 md:my-4 mb-6 md:text-lg text-sm font-bold tnum bg-white/5 border border-white/10 rounded-2xl px-3 py-2">
           {tokenFrom && (
             <>
               <TokenIcon
@@ -310,7 +310,7 @@ const renderChainflipStatus = (state: string) => {
                   className: "md:size-12 size-[27px]",
                 }}
               />
-              <div className="flex items-center gap-1 md:gap-2 ">
+              <div className="flex items-center gap-1 md:gap-2 min-w-0">
                 <span>{Number(amountFrom).toFixed(2)}</span>
                 <span>{tokenFrom.symbol}</span>
                 <span className="text-opacity-80 md:block hidden">
@@ -329,7 +329,7 @@ const renderChainflipStatus = (state: string) => {
                   className: "md:size-12 size-[27px]",
                 }}
               />
-              <div className="flex items-center gap-1 md:gap-2">
+              <div className="flex items-center gap-1 md:gap-2 min-w-0">
                 <span>{Number(amountTo).toFixed(2)}</span>
                 <span>{tokenTo.symbol}</span>
                 <span className="text-opacity-80 md:block hidden">

--- a/app/_components/dexifier/RouteCard.tsx
+++ b/app/_components/dexifier/RouteCard.tsx
@@ -77,7 +77,7 @@ const RouteCard = () => {
     <div className="relative w-full flex items-center gap-3.5">
       {providerStack(row.logos)}
       <div className="flex flex-col min-w-0 gap-0.5">
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 min-w-0">
           <span className="font-semibold truncate">{row.title}</span>
           {row.isBest && (
             <span className="rounded-full bg-primary px-2 py-0.5 text-[10px] font-bold text-black shadow-neon-sm">
@@ -375,7 +375,7 @@ const RouteCard = () => {
                 onValueChange={(value) =>
                   setSelectedRoute(sortedRoutes[parseInt(value)])
                 }
-                className="w-full h-full space-y-2"
+                className="w-full h-full space-y-2 [&>*]:min-w-0"
               >
                 {sortedRoutes.map((route, index) => {
                   const row: RowData | null =

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -70,7 +70,7 @@ export default function SwapPage() {
                   stiffness: 800,
                   mass: 1,
                 }}
-                className="h-full"
+                className="h-full min-w-0 w-full"
               >
                 <RouteCard />
               </motion.div>


### PR DESCRIPTION
- RouteCard rows forced the page wider than the viewport on mobile (grid items kept min-content width)
- grid children min-w-0 + title/chips row wraps
- AddressCard summary pill wraps so chain/coin text never spills past the border