### PR TITLE
Parallel route quotes with per-provider timeout

### DIFF
--- a/__tests__/routes.test.ts
+++ b/__tests__/routes.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api-client", () => ({
+  getChainflipQuotes: vi.fn(),
+  getExolixRate: vi.fn(),
+  getRangoRoutes: vi.fn(),
+}));
+
+import { fetchAllRoutes } from "../app/utils/routes";
+import {
+  getChainflipQuotes,
+  getExolixRate,
+  getRangoRoutes,
+} from "@/lib/api-client";
+import type { Token } from "../app/types/dexifier";
+
+const cfMock = vi.mocked(getChainflipQuotes);
+const exMock = vi.mocked(getExolixRate);
+const rangoMock = vi.mocked(getRangoRoutes);
+
+const token = (symbol: string, blockchain?: string): Token => ({
+  address: null,
+  symbol,
+  blockchain,
+});
+
+const baseParams = {
+  networks: [],
+  slippage: "1",
+  swapperGroups: [],
+  timeoutMs: 1000,
+};
+
+const cfQuote = { egressAmount: 2, ingressAsset: "btc.btc", egressAsset: "eth.eth" };
+const exRate = { toAmount: 3 };
+const rangoResult = (steps: number) => ({
+  swaps: Array.from({ length: steps }, (_, i) => ({ swapperId: `s${i}` })),
+  outputAmount: "1",
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  cfMock.mockResolvedValue([cfQuote] as never);
+  exMock.mockResolvedValue(exRate as never);
+  rangoMock.mockResolvedValue({ results: [rangoResult(2), rangoResult(1)] } as never);
+});
+
+describe("fetchAllRoutes", () => {
+  it("combines all providers in fixed slot order, even when a later slot answers first", async () => {
+    // Chainflip resolves last; slot order must still be chainflip → exolix → rango.
+    cfMock.mockImplementation(
+      () => new Promise((res) => setTimeout(() => res([cfQuote]), 40)) as never,
+    );
+    const routes = await fetchAllRoutes({
+      ...baseParams,
+      tokenFrom: token("BTC", "BTC"),
+      tokenTo: token("ETH", "ETH"),
+      amount: "1",
+      includeRango: true,
+    });
+    expect(routes).toHaveLength(4); // 1 chainflip + 1 exolix + 2 rango
+    expect("egressAmount" in routes[0]).toBe(true); // chainflip first
+    expect("toAmount" in routes[1]).toBe(true); // exolix second
+    expect("outputAmount" in routes[2]).toBe(true); // rango last
+    expect("outputAmount" in routes[3]).toBe(true);
+  });
+
+  it("sorts rango results by fewest steps", async () => {
+    const routes = await fetchAllRoutes({
+      ...baseParams,
+      tokenFrom: token("BTC", "BTC"),
+      tokenTo: token("ETH", "ETH"),
+      amount: "1",
+      includeRango: true,
+    });
+    const rango = routes.filter((r) => "outputAmount" in r) as {
+      swaps: unknown[];
+    }[];
+    expect(rango[0].swaps).toHaveLength(1);
+    expect(rango[1].swaps).toHaveLength(2);
+  });
+
+  it("survives a chainflip failure", async () => {
+    cfMock.mockRejectedValue(new Error("broker 504") as never);
+    const routes = await fetchAllRoutes({
+      ...baseParams,
+      tokenFrom: token("BTC", "BTC"),
+      tokenTo: token("ETH", "ETH"),
+      amount: "1",
+      includeRango: true,
+    });
+    expect(routes).toHaveLength(3); // 1 exolix + 2 rango
+    expect(routes.some((r) => "toAmount" in r)).toBe(true);
+    expect(routes.some((r) => "outputAmount" in r)).toBe(true);
+  });
+
+  it("survives an exolix failure", async () => {
+    exMock.mockRejectedValue(new Error("pair not available") as never);
+    const routes = await fetchAllRoutes({
+      ...baseParams,
+      tokenFrom: token("BTC", "BTC"),
+      tokenTo: token("ETH", "ETH"),
+      amount: "1",
+      includeRango: true,
+    });
+    expect(routes).toHaveLength(3); // 1 chainflip + 2 rango
+    expect(routes.some((r) => "egressAmount" in r)).toBe(true);
+    expect(routes.some((r) => "outputAmount" in r)).toBe(true);
+  });
+
+  it("never calls rango when includeRango is false (mobile)", async () => {
+    const routes = await fetchAllRoutes({
+      ...baseParams,
+      tokenFrom: token("BTC", "BTC"),
+      tokenTo: token("ETH", "ETH"),
+      amount: "1",
+      includeRango: false,
+    });
+    expect(rangoMock).not.toHaveBeenCalled();
+    expect(routes).toHaveLength(2);
+  });
+
+  it("skips chainflip when a chain is not in its map", async () => {
+    const routes = await fetchAllRoutes({
+      ...baseParams,
+      tokenFrom: token("XMR", "XMR"),
+      tokenTo: token("ETH", "ETH"),
+      amount: "1",
+      includeRango: false,
+    });
+    expect(cfMock).not.toHaveBeenCalled();
+    expect(routes).toHaveLength(1);
+  });
+
+  it("a hung provider times out and the rest still arrive", async () => {
+    cfMock.mockImplementation(() => new Promise(() => {}) as never); // never resolves
+    const routes = await fetchAllRoutes({
+      ...baseParams,
+      tokenFrom: token("BTC", "BTC"),
+      tokenTo: token("ETH", "ETH"),
+      amount: "1",
+      includeRango: true,
+      timeoutMs: 30,
+    });
+    expect(routes).toHaveLength(3); // exolix + 2 rango, no chainflip
+    expect(routes.some((r) => "egressAmount" in r)).toBe(false);
+  });
+
+  it("returns nothing and calls nobody when a chain is missing", async () => {
+    const routes = await fetchAllRoutes({
+      ...baseParams,
+      tokenFrom: token("BTC"),
+      tokenTo: token("ETH", "ETH"),
+      amount: "1",
+      includeRango: true,
+    });
+    expect(routes).toEqual([]);
+    expect(cfMock).not.toHaveBeenCalled();
+    expect(exMock).not.toHaveBeenCalled();
+    expect(rangoMock).not.toHaveBeenCalled();
+  });
+});

--- a/app/providers/DexifierProvider.tsx
+++ b/app/providers/DexifierProvider.tsx
@@ -6,27 +6,29 @@
 // (useDexifier) is provided for easier consumption of the context in components.
 
 import { createContext, useContext, ReactNode, SetStateAction, Dispatch, useState, useEffect, useMemo, useRef } from "react";
-import { BlockchainMeta, ConfirmRouteResponse, MultiRouteRequest, MultiRouteResponse, MultiRouteSimulationResult, Transaction, TransactionType } from "rango-types/mainApi"
+import { BlockchainMeta, ConfirmRouteResponse, Transaction, TransactionType } from "rango-types/mainApi"
 import { Settings } from "../types/rango";
-import { ChainflipSwapResponse, ChainflipQuote, ChainflipError, ChainflipSwapStatus } from "../types/chainflip";
-import { DCurrency, DNetwork, ExTxInfo, RateRequest, RateResponse, TxRequest } from "../types/exolix";
+import { ChainflipSwapResponse, ChainflipError, ChainflipSwapStatus } from "../types/chainflip";
+import { DCurrency, DNetwork, ExTxInfo, TxRequest } from "../types/exolix";
 import { ConnectedWallet, useWallets, useWidget } from "@rango-dev/widget-embedded";
 import { debounce } from "lodash";
-import { CHAINFLIP_BLOCKCHAIN_NAME_MAP } from "../utils/chainflip";
 import { ethers } from 'ethers';
 import {
   createChainflipSwap,
   createExolixTransaction,
-  getChainflipQuotes,
   getChainflipSwapStatus,
-  getExolixRate,
   getExolixTxInfo,
-  getRangoRoutes,
 } from "@/lib/api-client";
 import axios from "axios";
 import { MAP_BLOCKCHAIN_RANGO_2_EXOLIX, resolveExolixNetwork } from "../utils/exolix";
 import { dedupeTokens } from "../utils/tokens";
+import { fetchAllRoutes } from "../utils/routes";
+import type { DexifierRoute } from "../utils/routes";
 import { Blockchain, Token } from "../types/dexifier";
+
+// Re-exported so existing consumers can keep importing the route union from
+// this module while the type itself lives with the fetch logic.
+export type { DexifierRoute };
 
 // Define the type for the context
 interface DexifierContextType {
@@ -96,8 +98,6 @@ export enum DEXIFIER_STATE {
   FAILED = 8,
   SUCCESS = 9,
 }
-
-export type DexifierRoute = MultiRouteSimulationResult | ChainflipQuote | RateResponse
 
 const DexifierProvider = ({ children }: { children: ReactNode }) => {
   const [tokenFrom, setTokenFrom] = useState<Token>();
@@ -177,58 +177,18 @@ const DexifierProvider = ({ children }: { children: ReactNode }) => {
     setSwapStatus(undefined)
   }
 
-  const getRoutes = async (tokenFrom: Token, tokenTo: Token, amount: string): Promise<DexifierRoute[]> => {
-    const allRoutes: DexifierRoute[] = []
-    if (!tokenFrom.blockchain || !tokenTo.blockchain) return [];
-    try {
-      if (tokenFrom.blockchain in CHAINFLIP_BLOCKCHAIN_NAME_MAP && tokenTo.blockchain in CHAINFLIP_BLOCKCHAIN_NAME_MAP) {
-        const chainflipQuotes = await getChainflipQuotes({
-          sourceAsset: `${tokenFrom.symbol.toLowerCase()}.${CHAINFLIP_BLOCKCHAIN_NAME_MAP[tokenFrom.blockchain]}`,
-          destinationAsset: `${tokenTo.symbol.toLowerCase()}.${CHAINFLIP_BLOCKCHAIN_NAME_MAP[tokenTo.blockchain]}`,
-          amount: amount,
-          commissionBps: 15,
-        });
-
-        // Query every provider and show all routes side by side — never
-        // return early just because Chainflip answered.
-        allRoutes.push(...chainflipQuotes)
-      }
-    } catch (error) { }
-    try {
-      const exolixRateRequest: RateRequest = {
-        coinFrom: tokenFrom.symbol,
-        networkFrom: resolveExolixNetwork(tokenFrom.blockchain, networks),
-        coinTo: tokenTo.symbol,
-        networkTo: resolveExolixNetwork(tokenTo.blockchain, networks),
-        amount: amount,
-        rateType: 'float',
-      }
-      const exolixRateResponse: RateResponse = await getExolixRate(exolixRateRequest)
-      allRoutes.push(exolixRateResponse)
-    } catch (error) { }
-    if (!isMobile) try {
-      const rangoMultiRouteRequest: MultiRouteRequest = {
-        amount: amount,
-        from: {
-          address: tokenFrom.address,
-          blockchain: tokenFrom.blockchain,
-          symbol: tokenFrom.symbol,
-        },
-        to: {
-          address: tokenTo.address,
-          blockchain: tokenTo.blockchain,
-          symbol: tokenTo.symbol,
-        },
-        slippage: settings.slippage.toString(),
-        swapperGroups: settings.swappers.map(swapper => swapper.swapperGroup),
-        swappersGroupsExclude: false,
-      }
-      const rangoMultiRouteResponse: MultiRouteResponse = await getRangoRoutes(rangoMultiRouteRequest)
-      const rangoMultiRouteSimulationResults: MultiRouteSimulationResult[] = rangoMultiRouteResponse.results.sort((a, b) => a.swaps.length - b.swaps.length);
-      allRoutes.push(...rangoMultiRouteSimulationResults)
-    } catch (error) { }
-    return allRoutes
-  }
+  // All providers are queried in parallel (see utils/routes) — a hung
+  // provider times out on its own instead of delaying the whole panel.
+  const getRoutes = (tokenFrom: Token, tokenTo: Token, amount: string): Promise<DexifierRoute[]> =>
+    fetchAllRoutes({
+      tokenFrom,
+      tokenTo,
+      amount,
+      networks,
+      includeRango: !isMobile,
+      slippage: settings.slippage.toString(),
+      swapperGroups: settings.swappers.map(swapper => swapper.swapperGroup),
+    });
 
   const createSwap = async () => {
     if (!withdrawalAddress || !tokenFrom || !tokenTo || !amountFrom || !selectedRoute)

--- a/app/utils/routes.ts
+++ b/app/utils/routes.ts
@@ -1,0 +1,116 @@
+import type { MultiRouteRequest, MultiRouteSimulationResult } from "rango-types/mainApi";
+import type { ChainflipQuote } from "../types/chainflip";
+import type { DNetwork, RateResponse } from "../types/exolix";
+import type { Token } from "../types/dexifier";
+import { CHAINFLIP_BLOCKCHAIN_NAME_MAP } from "./chainflip";
+import { resolveExolixNetwork } from "./exolix";
+import { getChainflipQuotes, getExolixRate, getRangoRoutes } from "@/lib/api-client";
+
+export type DexifierRoute = MultiRouteSimulationResult | ChainflipQuote | RateResponse;
+
+// One slow or hung provider must never hold back the others' quotes.
+export const PROVIDER_TIMEOUT_MS = 20_000;
+
+const withProviderTimeout = <T>(
+  promise: Promise<T>,
+  ms: number,
+  label: string,
+): Promise<T> =>
+  Promise.race([
+    promise,
+    new Promise<T>((_, reject) =>
+      setTimeout(() => reject(new Error(`${label} quote timed out`)), ms),
+    ),
+  ]);
+
+export interface FetchRoutesParams {
+  tokenFrom: Token;
+  tokenTo: Token;
+  amount: string;
+  networks: DNetwork[];
+  includeRango: boolean; // false on mobile — browser wallets don't work there
+  slippage: string;
+  swapperGroups: MultiRouteRequest["swapperGroups"];
+  timeoutMs?: number; // tests inject a tiny value
+}
+
+// Query Chainflip, Exolix and (optionally) Rango concurrently. Results come
+// back in a fixed slot order (chainflip → exolix → rango) regardless of which
+// provider answered first; a failed or timed-out provider contributes nothing.
+export async function fetchAllRoutes({
+  tokenFrom,
+  tokenTo,
+  amount,
+  networks,
+  includeRango,
+  slippage,
+  swapperGroups,
+  timeoutMs = PROVIDER_TIMEOUT_MS,
+}: FetchRoutesParams): Promise<DexifierRoute[]> {
+  if (!tokenFrom.blockchain || !tokenTo.blockchain) return [];
+
+  const chainflipQuotes: Promise<ChainflipQuote[]> =
+    tokenFrom.blockchain in CHAINFLIP_BLOCKCHAIN_NAME_MAP &&
+    tokenTo.blockchain in CHAINFLIP_BLOCKCHAIN_NAME_MAP
+      ? withProviderTimeout(
+          getChainflipQuotes({
+            sourceAsset: `${tokenFrom.symbol.toLowerCase()}.${CHAINFLIP_BLOCKCHAIN_NAME_MAP[tokenFrom.blockchain]}`,
+            destinationAsset: `${tokenTo.symbol.toLowerCase()}.${CHAINFLIP_BLOCKCHAIN_NAME_MAP[tokenTo.blockchain]}`,
+            amount: amount,
+            commissionBps: 15,
+          }),
+          timeoutMs,
+          "Chainflip",
+        )
+      : Promise.resolve([]);
+
+  const exolixRate: Promise<RateResponse[]> = withProviderTimeout(
+    getExolixRate({
+      coinFrom: tokenFrom.symbol,
+      networkFrom: resolveExolixNetwork(tokenFrom.blockchain, networks),
+      coinTo: tokenTo.symbol,
+      networkTo: resolveExolixNetwork(tokenTo.blockchain, networks),
+      amount: amount,
+      rateType: "float",
+    }).then((rate) => [rate]),
+    timeoutMs,
+    "Exolix",
+  );
+
+  const rangoRoutes: Promise<MultiRouteSimulationResult[]> = !includeRango
+    ? Promise.resolve([])
+    : withProviderTimeout(
+        getRangoRoutes({
+          amount: amount,
+          from: {
+            address: tokenFrom.address,
+            blockchain: tokenFrom.blockchain,
+            symbol: tokenFrom.symbol,
+          },
+          to: {
+            address: tokenTo.address,
+            blockchain: tokenTo.blockchain,
+            symbol: tokenTo.symbol,
+          },
+          slippage: slippage,
+          swapperGroups: swapperGroups,
+          swappersGroupsExclude: false,
+        }).then((response) =>
+          response.results.sort((a, b) => a.swaps.length - b.swaps.length),
+        ),
+        timeoutMs,
+        "Rango",
+      );
+
+  const [chainflip, exolix, rango] = await Promise.allSettled([
+    chainflipQuotes,
+    exolixRate,
+    rangoRoutes,
+  ]);
+
+  const allRoutes: DexifierRoute[] = [];
+  if (chainflip.status === "fulfilled") allRoutes.push(...chainflip.value);
+  if (exolix.status === "fulfilled") allRoutes.push(...exolix.value);
+  if (rango.status === "fulfilled") allRoutes.push(...rango.value);
+  return allRoutes;
+}


### PR DESCRIPTION
## What
Route quoting was sequential (Chainflip → Exolix → Rango), so one slow provider delayed the whole panel — worst on mobile, where wallet-less quotes are the only ones and Chainflip's broker API occasionally 504s.

## How
- New `app/utils/routes.ts` → `fetchAllRoutes()`: fires all providers concurrently, 20s per-provider timeout, merges in fixed slot order (chainflip → exolix → rango) regardless of response order. Failures contribute nothing (same as the old try/catch).
- `DexifierRoute` union moved next to the fetch logic; re-exported from DexifierProvider so consumers are untouched.
- 8 new unit tests (70 total): slot order with out-of-order resolution, failure isolation per provider, hang timeout, mobile skips Rango, unmapped chains skip Chainflip.

## Verification
tsc clean, eslint 0 errors, 70/70 vitest. Live: desktop + iPhone-UA probes confirm route panels render and ordering is unchanged.
